### PR TITLE
feat: add postgres ORM models and migrations

### DIFF
--- a/backend/core/models/__init__.py
+++ b/backend/core/models/__init__.py
@@ -1,1 +1,42 @@
-"""Core data models."""
+"""SQLAlchemy declarative base and model exports."""
+
+from __future__ import annotations
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase
+
+NAMING_CONVENTION = {
+    "ix": "ix_%(table_name)s_%(column_0_N_name)s",
+    "uq": "uq_%(table_name)s_%(column_0_N_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_N_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class Base(DeclarativeBase):
+    """Declarative base class for all ORM models."""
+
+    metadata = MetaData(naming_convention=NAMING_CONVENTION)
+
+
+from .artifact import Artifact, ArtifactKind
+from .event import Event, EventType
+from .run import PullRequestBinding, Run, RunStatus
+from .step import Step, StepStatus
+from .validation import ValidationReport
+
+__all__ = [
+    "Artifact",
+    "ArtifactKind",
+    "Base",
+    "Event",
+    "EventType",
+    "NAMING_CONVENTION",
+    "PullRequestBinding",
+    "Run",
+    "RunStatus",
+    "Step",
+    "StepStatus",
+    "ValidationReport",
+]

--- a/backend/core/models/artifact.py
+++ b/backend/core/models/artifact.py
@@ -1,30 +1,67 @@
-"""Artifact model definitions."""
+"""SQLAlchemy models for step artifacts."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import uuid
 from datetime import datetime
-from typing import Dict, Optional
+from enum import Enum
+from typing import Dict
+
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy import ForeignKey, Text, func, text
+from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
 
 
-@dataclass
-class Artifact:
-    """Represents an artifact generated during a run step.
+class ArtifactKind(str, Enum):
+    """Enumeration of artifact classifications."""
 
-    Attributes:
-        id: Unique identifier for the artifact.
-        run_id: Associated run identifier.
-        step_id: Associated step identifier.
-        created_at: Creation timestamp in UTC.
-        artifact_type: Type descriptor (e.g., diff, log, asset).
-        storage_url: Location where the artifact is persisted.
-        metadata: Optional metadata for consumers.
-    """
+    DIFF = "diff"
+    DOC = "doc"
+    LOG = "log"
+    BLOB = "blob"
+    REJECTION = "rej"
 
-    id: str
-    run_id: str
-    step_id: str
-    created_at: datetime
-    artifact_type: str
-    storage_url: str
-    metadata: Optional[Dict[str, object]]
+
+class Artifact(Base):
+    """Persistence model for artifacts generated during a step."""
+
+    __tablename__ = "artifacts"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    step_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("steps.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    kind: Mapped[ArtifactKind] = mapped_column(
+        SAEnum(ArtifactKind, name="artifact_kind", native_enum=False, validate_strings=True),
+        nullable=False,
+    )
+    uri: Mapped[str] = mapped_column(Text, nullable=False)
+    meta: Mapped[Dict[str, object]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    step: Mapped["Step"] = relationship(
+        "Step",
+        back_populates="artifacts",
+        passive_deletes=True,
+    )
+
+
+__all__ = ["Artifact", "ArtifactKind"]

--- a/backend/core/models/event.py
+++ b/backend/core/models/event.py
@@ -1,0 +1,77 @@
+"""SQLAlchemy model for lifecycle events."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Optional
+
+import uuid
+
+from sqlalchemy import BigInteger, Enum as SAEnum, ForeignKey, func, text
+from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+from backend.core.events.lifecycle import LifecycleEventType
+
+
+class EventType(str, Enum):
+    """Enumeration of persisted event types."""
+
+    RUN_CREATED = LifecycleEventType.RUN_CREATED.value
+    RUN_COMPLETED = LifecycleEventType.RUN_COMPLETED.value
+    STEP_PLANNED = LifecycleEventType.STEP_PLANNED.value
+    STEP_EXECUTING = LifecycleEventType.STEP_EXECUTING.value
+    STEP_VALIDATED = LifecycleEventType.STEP_VALIDATED.value
+    STEP_FAILED = LifecycleEventType.STEP_FAILED.value
+    STEP_COMMITTED = LifecycleEventType.STEP_COMMITTED.value
+    STEP_MERGED = LifecycleEventType.STEP_MERGED.value
+
+
+class Event(Base):
+    """Persistence model representing run and step lifecycle events."""
+
+    __tablename__ = "events"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("runs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    step_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("steps.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    type: Mapped[EventType] = mapped_column(
+        SAEnum(EventType, name="event_type", native_enum=False, validate_strings=True),
+        nullable=False,
+    )
+    payload: Mapped[Dict[str, object]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    ts: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    run: Mapped["Run"] = relationship(
+        "Run",
+        back_populates="events",
+        passive_deletes=True,
+    )
+    step: Mapped[Optional["Step"]] = relationship(
+        "Step",
+        back_populates="events",
+        passive_deletes=True,
+    )
+
+
+__all__ = ["Event", "EventType"]

--- a/backend/core/models/run.py
+++ b/backend/core/models/run.py
@@ -1,26 +1,99 @@
-"""Run model definitions."""
+"""SQLAlchemy models for run entities."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import uuid
 from datetime import datetime
-from typing import Dict, Optional
+from enum import Enum
+from typing import List, Optional
+
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy import ForeignKey, Integer, Text, func, text
+from sqlalchemy.dialects.postgresql import TIMESTAMP, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
 
 
-@dataclass
-class Run:
-    """Represents a top-level execution run for the orchestrator.
+class RunStatus(str, Enum):
+    """Enumeration of run lifecycle states."""
 
-    Attributes:
-        id: Unique identifier for the run.
-        created_at: Creation timestamp in UTC.
-        updated_at: Last update timestamp in UTC.
-        status: High-level status (e.g., pending, running, completed).
-        metadata: Optional JSON-serializable metadata payload.
-    """
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
 
-    id: str
-    created_at: datetime
-    updated_at: datetime
-    status: str
-    metadata: Optional[Dict[str, object]]
+
+class Run(Base):
+    """Persistence model representing a workflow run."""
+
+    __tablename__ = "runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    repo: Mapped[str] = mapped_column(Text, nullable=False)
+    base_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    branch_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[RunStatus] = mapped_column(
+        SAEnum(RunStatus, name="run_status", native_enum=False, validate_strings=True),
+        nullable=False,
+        default=RunStatus.PENDING,
+        server_default=text("'pending'"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    steps: Mapped[List["Step"]] = relationship(
+        "Step",
+        back_populates="run",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    pull_request_binding: Mapped[Optional["PullRequestBinding"]] = relationship(
+        "PullRequestBinding",
+        back_populates="run",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        uselist=False,
+    )
+    events: Mapped[List["Event"]] = relationship(
+        "Event",
+        back_populates="run",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class PullRequestBinding(Base):
+    """Persistence model mapping runs to GitHub pull requests."""
+
+    __tablename__ = "pr_bindings"
+
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("runs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    pr_url: Mapped[str] = mapped_column(Text, nullable=False)
+
+    run: Mapped[Run] = relationship(
+        "Run",
+        back_populates="pull_request_binding",
+        passive_deletes=True,
+    )
+
+
+__all__ = ["Run", "RunStatus", "PullRequestBinding"]

--- a/backend/core/models/step.py
+++ b/backend/core/models/step.py
@@ -1,30 +1,95 @@
-"""Run step model definitions."""
+"""SQLAlchemy models for run steps."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import uuid
 from datetime import datetime
-from typing import Dict, Optional
+from enum import Enum
+from typing import List
+
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy import ForeignKey, Integer, Text, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
 
 
-@dataclass
-class Step:
-    """Represents a single step within a run.
+class StepStatus(str, Enum):
+    """Enumeration of step lifecycle states."""
 
-    Attributes:
-        id: Unique identifier for the step.
-        run_id: Identifier of the owning run.
-        created_at: Creation timestamp in UTC.
-        updated_at: Last update timestamp in UTC.
-        status: Step lifecycle status.
-        payload: Serialized step definition payload.
-        result_metadata: Optional metadata from downstream agents.
-    """
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
 
-    id: str
-    run_id: str
-    created_at: datetime
-    updated_at: datetime
-    status: str
-    payload: Dict[str, object]
-    result_metadata: Optional[Dict[str, object]]
+
+class Step(Base):
+    """Persistence model representing a unit of work within a run."""
+
+    __tablename__ = "steps"
+    __table_args__ = (UniqueConstraint("run_id", "idx"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("runs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    idx: Mapped[int] = mapped_column(Integer, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[StepStatus] = mapped_column(
+        SAEnum(StepStatus, name="step_status", native_enum=False, validate_strings=True),
+        nullable=False,
+        default=StepStatus.PENDING,
+        server_default=text("'pending'"),
+    )
+    acceptance_criteria: Mapped[List[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'[]'::jsonb"),
+    )
+    plan_md: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    run: Mapped["Run"] = relationship(
+        "Run",
+        back_populates="steps",
+        passive_deletes=True,
+    )
+    artifacts: Mapped[List["Artifact"]] = relationship(
+        "Artifact",
+        back_populates="step",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    validation_reports: Mapped[List["ValidationReport"]] = relationship(
+        "ValidationReport",
+        back_populates="step",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    events: Mapped[List["Event"]] = relationship(
+        "Event",
+        back_populates="step",
+        passive_deletes=True,
+    )
+
+
+__all__ = ["Step", "StepStatus"]

--- a/backend/core/models/validation.py
+++ b/backend/core/models/validation.py
@@ -1,24 +1,56 @@
-"""Validation report model definitions."""
+"""SQLAlchemy models for validation reports."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Dict, List
+import uuid
+from datetime import datetime
+from typing import Dict
+
+from sqlalchemy import ForeignKey, Integer, func, text
+from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
 
 
-@dataclass
-class ValidationMessage:
-    """Represents a single validation message entry."""
+class ValidationReport(Base):
+    """Persistence model capturing validator outputs for a step."""
 
-    code: str
-    file: str
-    message: str
+    __tablename__ = "validation_reports"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    step_id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("steps.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    report: Mapped[Dict[str, object]] = mapped_column(JSONB, nullable=False)
+    fatal_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        server_default=text("0"),
+    )
+    warnings_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        server_default=text("0"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    step: Mapped["Step"] = relationship(
+        "Step",
+        back_populates="validation_reports",
+        passive_deletes=True,
+    )
 
 
-@dataclass
-class ValidationReport:
-    """Represents the validator output for a set of changes."""
-
-    fatal: List[ValidationMessage] = field(default_factory=list)
-    warnings: List[ValidationMessage] = field(default_factory=list)
-    metrics: Dict[str, int] = field(default_factory=dict)
+__all__ = ["ValidationReport"]

--- a/backend/core/store/__init__.py
+++ b/backend/core/store/__init__.py
@@ -1,1 +1,15 @@
-"""Database store package."""
+"""Database store package exports."""
+
+from backend.core.store.session import (
+    configure_engine,
+    get_engine,
+    get_session_factory,
+    session_scope,
+)
+
+__all__ = [
+    "configure_engine",
+    "get_engine",
+    "get_session_factory",
+    "session_scope",
+]

--- a/backend/core/store/migrations/versions/20240606_01_core_tables.py
+++ b/backend/core/store/migrations/versions/20240606_01_core_tables.py
@@ -1,0 +1,165 @@
+"""Create core persistence tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20240606_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+RUN_STATUS = ("pending", "running", "completed", "failed", "cancelled")
+STEP_STATUS = ("pending", "running", "completed", "failed", "skipped")
+ARTIFACT_KINDS = ("diff", "doc", "log", "blob", "rej")
+EVENT_TYPES = (
+    "run.created",
+    "run.completed",
+    "step.planned",
+    "step.executing",
+    "step.validated",
+    "step.failed",
+    "step.committed",
+    "step.merged",
+)
+
+
+CREATE_UPDATED_AT_TRIGGER = """
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+RUN_TRIGGER = """
+CREATE TRIGGER runs_set_updated_at
+BEFORE UPDATE ON runs
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+"""
+
+
+STEP_TRIGGER = """
+CREATE TRIGGER steps_set_updated_at
+BEFORE UPDATE ON steps
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+"""
+
+
+DROP_RUN_TRIGGER = "DROP TRIGGER IF EXISTS runs_set_updated_at ON runs;"
+DROP_STEP_TRIGGER = "DROP TRIGGER IF EXISTS steps_set_updated_at ON steps;"
+DROP_TRIGGER_FUNCTION = "DROP FUNCTION IF EXISTS set_updated_at();"
+
+
+def upgrade() -> None:
+    run_status_enum = sa.Enum(*RUN_STATUS, name="run_status", native_enum=False, create_constraint=True)
+    step_status_enum = sa.Enum(*STEP_STATUS, name="step_status", native_enum=False, create_constraint=True)
+    artifact_kind_enum = sa.Enum(*ARTIFACT_KINDS, name="artifact_kind", native_enum=False, create_constraint=True)
+    event_type_enum = sa.Enum(*EVENT_TYPES, name="event_type", native_enum=False, create_constraint=True)
+
+    op.create_table(
+        "runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("repo", sa.Text(), nullable=False),
+        sa.Column("base_ref", sa.Text(), nullable=False),
+        sa.Column("branch_ref", sa.Text(), nullable=False),
+        sa.Column("status", run_status_enum, nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+
+    op.create_table(
+        "steps",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("idx", sa.Integer(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("status", step_status_enum, nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("acceptance_criteria", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'[]'::jsonb")),
+        sa.Column("plan_md", sa.Text(), nullable=True),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["run_id"], ["runs.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("run_id", "idx"),
+    )
+    op.create_index(op.f("ix_steps_run_id"), "steps", ["run_id"], unique=False)
+
+    op.create_table(
+        "artifacts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("step_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kind", artifact_kind_enum, nullable=False),
+        sa.Column("uri", sa.Text(), nullable=False),
+        sa.Column("meta", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["step_id"], ["steps.id"], ondelete="CASCADE"),
+    )
+    op.create_index(op.f("ix_artifacts_step_id"), "artifacts", ["step_id"], unique=False)
+
+    op.create_table(
+        "validation_reports",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("step_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("report", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("fatal_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("warnings_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["step_id"], ["steps.id"], ondelete="CASCADE"),
+    )
+    op.create_index(op.f("ix_validation_reports_step_id"), "validation_reports", ["step_id"], unique=False)
+
+    op.create_table(
+        "pr_bindings",
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=False),
+        sa.Column("pr_url", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["run_id"], ["runs.id"], ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "events",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("step_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("type", event_type_enum, nullable=False),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("ts", postgresql.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["run_id"], ["runs.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["step_id"], ["steps.id"], ondelete="CASCADE"),
+    )
+    op.create_index(op.f("ix_events_run_id"), "events", ["run_id"], unique=False)
+    op.create_index(op.f("ix_events_step_id"), "events", ["step_id"], unique=False)
+
+    op.execute(CREATE_UPDATED_AT_TRIGGER)
+    op.execute(RUN_TRIGGER)
+    op.execute(STEP_TRIGGER)
+
+
+def downgrade() -> None:
+    op.execute(DROP_RUN_TRIGGER)
+    op.execute(DROP_STEP_TRIGGER)
+    op.execute(DROP_TRIGGER_FUNCTION)
+
+    op.drop_index(op.f("ix_events_step_id"), table_name="events")
+    op.drop_index(op.f("ix_events_run_id"), table_name="events")
+    op.drop_table("events")
+
+    op.drop_table("pr_bindings")
+
+    op.drop_index(op.f("ix_validation_reports_step_id"), table_name="validation_reports")
+    op.drop_table("validation_reports")
+
+    op.drop_index(op.f("ix_artifacts_step_id"), table_name="artifacts")
+    op.drop_table("artifacts")
+
+    op.drop_index(op.f("ix_steps_run_id"), table_name="steps")
+    op.drop_table("steps")
+
+    op.drop_table("runs")

--- a/backend/core/store/migrations/versions/__init__.py
+++ b/backend/core/store/migrations/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Alembic revision scripts."""

--- a/backend/core/store/repositories.py
+++ b/backend/core/store/repositories.py
@@ -1,70 +1,222 @@
-"""Repository interfaces for persistence operations."""
+"""Repository stubs for database persistence."""
 
 from __future__ import annotations
 
-from typing import Protocol
+import uuid
+from datetime import datetime
+from typing import Optional, Sequence
 
-from backend.core.models.artifact import Artifact
-from backend.core.models.run import Run
-from backend.core.models.step import Step
+from sqlalchemy.orm import Session
+
+from backend.core.models.artifact import Artifact, ArtifactKind
+from backend.core.models.event import Event, EventType
+from backend.core.models.run import PullRequestBinding, Run, RunStatus
+from backend.core.models.step import Step, StepStatus
 from backend.core.models.validation import ValidationReport
 
 
-class RunRepository(Protocol):
-    """Persistence operations for runs."""
+class RunRepository:
+    """CRUD operations for run aggregates."""
 
-    def create(self, run: Run) -> Run:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(self, *, repo: str, base_ref: str, branch_ref: str) -> Run:
         """Persist a new run entity."""
-        ...
 
-    def get(self, run_id: str) -> Run:
+        raise NotImplementedError
+
+    def get(self, run_id: uuid.UUID) -> Optional[Run]:
         """Retrieve a run by identifier."""
-        ...
+
+        raise NotImplementedError
+
+    def list(self) -> Sequence[Run]:
+        """List all persisted runs."""
+
+        raise NotImplementedError
+
+    def update_status(self, run_id: uuid.UUID, status: RunStatus) -> Run:
+        """Update the status of an existing run."""
+
+        raise NotImplementedError
+
+    def delete(self, run_id: uuid.UUID) -> None:
+        """Delete a run and cascade to dependents."""
+
+        raise NotImplementedError
 
 
-class StepRepository(Protocol):
-    """Persistence operations for steps."""
+class StepRepository:
+    """CRUD operations for run steps."""
 
-    def create(self, step: Step) -> Step:
-        """Persist a new step entity."""
-        ...
+    def __init__(self, session: Session) -> None:
+        self._session = session
 
-    def update(self, step: Step) -> Step:
-        """Update an existing step entity."""
-        ...
+    def create(
+        self,
+        *,
+        run_id: uuid.UUID,
+        idx: int,
+        title: str,
+        body: str,
+        status: StepStatus = StepStatus.PENDING,
+    ) -> Step:
+        """Persist a new step for a run."""
 
-    def get(self, step_id: str) -> Step:
-        """Retrieve a step by identifier."""
-        ...
+        raise NotImplementedError
+
+    def get(self, step_id: uuid.UUID) -> Optional[Step]:
+        """Fetch a step by identifier."""
+
+        raise NotImplementedError
+
+    def list_for_run(self, run_id: uuid.UUID) -> Sequence[Step]:
+        """List all steps for a given run."""
+
+        raise NotImplementedError
+
+    def update_status(self, step_id: uuid.UUID, status: StepStatus) -> Step:
+        """Update the lifecycle status for a step."""
+
+        raise NotImplementedError
+
+    def delete(self, step_id: uuid.UUID) -> None:
+        """Remove a step and its dependents."""
+
+        raise NotImplementedError
 
 
-class ArtifactRepository(Protocol):
-    """Persistence operations for artifacts."""
+class ArtifactRepository:
+    """CRUD operations for artifacts."""
 
-    def create(self, artifact: Artifact) -> Artifact:
-        """Persist a new artifact entity."""
-        ...
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        step_id: uuid.UUID,
+        kind: ArtifactKind,
+        uri: str,
+        meta: Optional[dict] = None,
+    ) -> Artifact:
+        """Persist a new artifact for a step."""
+
+        raise NotImplementedError
+
+    def get(self, artifact_id: uuid.UUID) -> Optional[Artifact]:
+        """Retrieve an artifact by identifier."""
+
+        raise NotImplementedError
+
+    def list_for_step(self, step_id: uuid.UUID) -> Sequence[Artifact]:
+        """List artifacts associated with a step."""
+
+        raise NotImplementedError
+
+    def delete(self, artifact_id: uuid.UUID) -> None:
+        """Delete an artifact."""
+
+        raise NotImplementedError
 
 
-class EventRepository(Protocol):
-    """Persistence operations for lifecycle events."""
+class ValidationReportRepository:
+    """CRUD operations for validation reports."""
 
-    def publish(self, event_payload: dict) -> None:
-        """Persist a lifecycle event payload."""
-        ...
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        step_id: uuid.UUID,
+        report: dict,
+        fatal_count: int = 0,
+        warnings_count: int = 0,
+    ) -> ValidationReport:
+        """Persist a validation report for a step."""
+
+        raise NotImplementedError
+
+    def get(self, report_id: uuid.UUID) -> Optional[ValidationReport]:
+        """Retrieve a validation report by identifier."""
+
+        raise NotImplementedError
+
+    def get_for_step(self, step_id: uuid.UUID) -> Optional[ValidationReport]:
+        """Retrieve the latest validation report for a step."""
+
+        raise NotImplementedError
+
+    def update_counts(
+        self,
+        report_id: uuid.UUID,
+        *,
+        fatal_count: int,
+        warnings_count: int,
+    ) -> ValidationReport:
+        """Update aggregated counts for a validation report."""
+
+        raise NotImplementedError
+
+    def delete(self, report_id: uuid.UUID) -> None:
+        """Delete a validation report."""
+
+        raise NotImplementedError
 
 
-class ValidationReportRepository(Protocol):
-    """Persistence operations for validation reports."""
+class PullRequestBindingRepository:
+    """CRUD operations for pull request bindings."""
 
-    def upsert(self, step_id: str, report: ValidationReport) -> ValidationReport:
-        """Persist or update a validation report."""
-        ...
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def bind(self, run_id: uuid.UUID, pr_number: int, pr_url: str) -> PullRequestBinding:
+        """Create or update a PR binding for a run."""
+
+        raise NotImplementedError
+
+    def get(self, run_id: uuid.UUID) -> Optional[PullRequestBinding]:
+        """Retrieve the PR binding for a run."""
+
+        raise NotImplementedError
+
+    def delete(self, run_id: uuid.UUID) -> None:
+        """Remove the PR binding for a run."""
+
+        raise NotImplementedError
 
 
-class PullRequestBindingRepository(Protocol):
-    """Persistence operations for PR bindings."""
+class EventRepository:
+    """CRUD operations for lifecycle events."""
 
-    def upsert(self, run_id: str, pr_number: int, branch: str) -> None:
-        """Persist or update the PR binding for a run."""
-        ...
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def record(
+        self,
+        *,
+        run_id: uuid.UUID,
+        step_id: Optional[uuid.UUID],
+        event_type: EventType,
+        payload: Optional[dict] = None,
+    ) -> Event:
+        """Persist a lifecycle event."""
+
+        raise NotImplementedError
+
+    def list_for_run(self, run_id: uuid.UUID) -> Sequence[Event]:
+        """List events associated with a run."""
+
+        raise NotImplementedError
+
+    def delete_for_run(self, run_id: uuid.UUID) -> None:
+        """Delete all events for a run."""
+
+        raise NotImplementedError
+
+    def purge_before(self, threshold_ts: datetime) -> int:
+        """Delete events older than a timestamp threshold."""
+
+        raise NotImplementedError

--- a/backend/core/store/session.py
+++ b/backend/core/store/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from contextlib import contextmanager
 from typing import Generator
 
@@ -10,22 +11,30 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 _ENGINE: Engine | None = None
-_SessionFactory: sessionmaker | None = None
+_SESSION_FACTORY: sessionmaker[Session] | None = None
 
 
-def configure_engine(dsn: str) -> None:
+def configure_engine(dsn: str | None = None) -> None:
     """Configure the global SQLAlchemy engine.
 
     Args:
-        dsn: Database connection string.
+        dsn: Optional database connection string. If omitted, ``DB_DSN`` is read from
+            the environment.
+
+    Raises:
+        RuntimeError: If no DSN is provided or found in the environment.
 
     Note:
         # TODO(team, 2024-05-22): Harden connection pooling and retries for production.
     """
 
-    global _ENGINE, _SessionFactory
-    _ENGINE = create_engine(dsn, pool_pre_ping=True, future=True)
-    _SessionFactory = sessionmaker(bind=_ENGINE, class_=Session, expire_on_commit=False)
+    database_dsn = dsn or os.getenv("DB_DSN")
+    if not database_dsn:
+        raise RuntimeError("DB_DSN environment variable is required to configure the engine.")
+
+    global _ENGINE, _SESSION_FACTORY
+    _ENGINE = create_engine(database_dsn, pool_pre_ping=True, future=True)
+    _SESSION_FACTORY = sessionmaker(bind=_ENGINE, class_=Session, expire_on_commit=False)
 
 
 def get_engine() -> Engine:
@@ -54,10 +63,22 @@ def session_scope() -> Generator[Session, None, None]:
         RuntimeError: If the session factory has not been configured.
     """
 
-    if _SessionFactory is None:
+    if _SESSION_FACTORY is None:
         raise RuntimeError("Session factory is not configured.")
-    session: Session = _SessionFactory()
+    session: Session = _SESSION_FACTORY()
     try:
         yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
     finally:
         session.close()
+
+
+def get_session_factory() -> sessionmaker[Session]:
+    """Return the configured session factory."""
+
+    if _SESSION_FACTORY is None:
+        raise RuntimeError("Session factory is not configured.")
+    return _SESSION_FACTORY


### PR DESCRIPTION
## Summary
- implement SQLAlchemy models for runs, steps, artifacts, validation reports, PR bindings, and events
- add Alembic migration establishing tables, constraints, triggers, and indexes
- update store session factory, migration hooks, and repository CRUD stubs

## Testing
- python -m compileall backend/core/models backend/core/store

------
https://chatgpt.com/codex/tasks/task_e_68db8aaac56c8331808ff1b91e690d5b