### PR TITLE
feat: add versioned contracts layer

### DIFF
--- a/core/contracts/__init__.py
+++ b/core/contracts/__init__.py
@@ -1,11 +1,33 @@
-"""Import-safe placeholder for domain contracts.
+"""Contracts package exports."""
 
-Real contract models will be introduced in follow-up iterations. The module
-exists today so that other packages can import :mod:`core.contracts` without
-triggering ``ImportError`` at runtime.
-"""
+from .base import BaseContract, ModelVersion
+from .coder_result import CoderResult
+from .events import StepStatusPayload
+from .mapping import ALIASES, STEP_TO_OUTPUT, normalize_step_type
+from .registry import ContractRegistry, register_contract, registry
+from .transforms import DEFAULT_TRANSFORMS, Transform, apply_transforms
+from .validation_report import Issue, ValidationReport
+from .version import DEFAULT_VERSION, SCHEMA_NS
+from .work_order import WorkOrder
 
-from __future__ import annotations
-
-__all__ = []
+__all__ = [
+    "ALIASES",
+    "BaseContract",
+    "CoderResult",
+    "ContractRegistry",
+    "DEFAULT_TRANSFORMS",
+    "DEFAULT_VERSION",
+    "Issue",
+    "ModelVersion",
+    "SCHEMA_NS",
+    "STEP_TO_OUTPUT",
+    "StepStatusPayload",
+    "Transform",
+    "ValidationReport",
+    "WorkOrder",
+    "apply_transforms",
+    "normalize_step_type",
+    "register_contract",
+    "registry",
+]
 

--- a/core/contracts/base.py
+++ b/core/contracts/base.py
@@ -1,0 +1,82 @@
+"""Base contract definitions for Pydantic models."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, ClassVar, Dict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .version import DEFAULT_VERSION, SCHEMA_NS
+
+
+class ModelVersion:
+    """Helpers for contract schema identifiers."""
+
+    @staticmethod
+    def make_schema_id(name: str, version: str) -> str:
+        """Return a schema identifier for the given contract name and version."""
+
+        return f"{SCHEMA_NS}/{name}/{version}"
+
+
+class BaseContract(BaseModel):
+    """Base class for all contract models."""
+
+    model_config = ConfigDict(extra="forbid", frozen=False, ser_json_inf_nan=False)
+
+    schema_version: str = Field(default="")
+    schema_id: str = Field(default="")
+
+    __contract_name__: ClassVar[str | None] = None
+    __contract_version__: ClassVar[str] = DEFAULT_VERSION
+
+    def model_post_init(self, __context: Any) -> None:
+        schema_version = self.schema_version or self.contract_version()
+        schema_id = self.schema_id or self.default_schema_id()
+        object.__setattr__(self, "schema_version", schema_version)
+        object.__setattr__(self, "schema_id", schema_id)
+
+    @classmethod
+    def contract_name(cls) -> str:
+        """Return the canonical contract name."""
+
+        name = getattr(cls, "__contract_name__", None)
+        return name or cls.__name__
+
+    @classmethod
+    def contract_version(cls) -> str:
+        """Return the contract version."""
+
+        return getattr(cls, "__contract_version__", DEFAULT_VERSION)
+
+    @classmethod
+    def default_schema_id(cls) -> str:
+        """Return the default schema identifier for the contract."""
+
+        return ModelVersion.make_schema_id(cls.contract_name(), cls.contract_version())
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the model to a Python dictionary."""
+
+        return self.model_dump(mode="python")
+
+    def to_json(self) -> str:
+        """Serialize the model to JSON."""
+
+        return self.model_dump_json()
+
+    @classmethod
+    def model_json_schema(cls, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Return the JSON schema for the model with an injected identifier."""
+
+        schema = super().model_json_schema(*args, **kwargs)
+        schema.setdefault("$id", cls.default_schema_id())
+        return schema
+
+    @classmethod
+    def schema_json(cls) -> str:
+        """Return the JSON schema for the model."""
+
+        return json.dumps(cls.model_json_schema(), sort_keys=True)
+

--- a/core/contracts/coder_result.py
+++ b/core/contracts/coder_result.py
@@ -1,0 +1,20 @@
+"""Coder result contract."""
+
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from .base import BaseContract
+from .registry import register_contract
+from .version import DEFAULT_VERSION
+
+
+@register_contract(name="CoderResult", version=DEFAULT_VERSION, aliases=["coder_result"])
+class CoderResult(BaseContract):
+    """Payload returned by the coding agent."""
+
+    work_order_id: UUID
+    diff: str
+    notes: Optional[str] = None
+

--- a/core/contracts/events.py
+++ b/core/contracts/events.py
@@ -1,0 +1,30 @@
+"""Event payload contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+from uuid import UUID
+
+from pydantic import Field
+
+from .base import BaseContract
+from .registry import register_contract
+from .version import DEFAULT_VERSION
+
+
+@register_contract(
+    name="StepStatusPayload",
+    version=DEFAULT_VERSION,
+    aliases=["step_status", "step_status_payload"],
+)
+class StepStatusPayload(BaseContract):
+    """Payload published to the event bus for step status updates."""
+
+    run_id: UUID
+    step_id: UUID
+    state: str
+    timestamps: Dict[str, datetime] = Field(default_factory=dict)
+    durations_ms: Dict[str, float] = Field(default_factory=dict)
+    meta: Dict[str, Any] = Field(default_factory=dict)
+

--- a/core/contracts/mapping.py
+++ b/core/contracts/mapping.py
@@ -1,0 +1,47 @@
+"""Mapping tables between step types and output contracts."""
+
+from __future__ import annotations
+
+STEP_TO_OUTPUT = {
+    "code_generation": "file_patch",
+    "code_refactor": "file_patch",
+    "code_fix": "file_patch",
+    "test_generation": "file_patch",
+    "file_patch": "file_patch",
+    "code_review": "quality_result",
+    "style_check": "quality_result",
+    "format_fix": "quality_result",
+    "validate_code": "quality_result",
+    "generate_plan": "plan_result",
+    "validate_plan": "plan_result",
+    "execute_plan": "orchestrator_result",
+    "orchestrate_step": "orchestrator_result",
+    "memory_lookup": "context",
+    "context_fetch": "context",
+    "symbol_lookup": "context",
+}
+
+ALIASES = {
+    "gen_code": "code_generation",
+    "refactor_code": "code_refactor",
+    "fix_code": "code_fix",
+    "gen_tests": "test_generation",
+    "review_code": "code_review",
+    "lint": "style_check",
+    "format_code": "format_fix",
+    "plan": "generate_plan",
+    "plan_validate": "validate_plan",
+    "execute": "execute_plan",
+    "orchestrate": "orchestrate_step",
+    "lookup_memory": "memory_lookup",
+    "fetch_context": "context_fetch",
+    "lookup_symbol": "symbol_lookup",
+}
+
+
+def normalize_step_type(step_type: str) -> str:
+    """Return the canonical step type for the provided identifier."""
+
+    canonical = ALIASES.get(step_type, step_type)
+    return canonical
+

--- a/core/contracts/registry.py
+++ b/core/contracts/registry.py
@@ -1,0 +1,92 @@
+"""Registry for contract models."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Sequence, Tuple, Type, TypeVar
+
+from .base import BaseContract
+from .version import DEFAULT_VERSION
+
+
+ContractT = TypeVar("ContractT", bound=BaseContract)
+
+
+class ContractRegistry:
+    """In-memory registry for contract models."""
+
+    def __init__(self) -> None:
+        self._contracts: Dict[Tuple[str, str], Type[BaseContract]] = {}
+        self._default_versions: Dict[str, str] = {}
+        self._aliases: Dict[str, Tuple[str, str]] = {}
+
+    def register(
+        self,
+        model_cls: Type[ContractT],
+        *,
+        name: str | None = None,
+        version: str = DEFAULT_VERSION,
+        aliases: Iterable[str] | None = None,
+    ) -> Type[ContractT]:
+        """Register a contract model and optional aliases."""
+
+        contract_name = name or model_cls.contract_name()
+        model_cls.__contract_name__ = contract_name
+        model_cls.__contract_version__ = version
+
+        key = (contract_name, version)
+        if key in self._contracts and self._contracts[key] is not model_cls:
+            raise ValueError(f"Contract already registered for {contract_name} v{version}")
+
+        self._contracts[key] = model_cls
+        self._default_versions.setdefault(contract_name, version)
+
+        for alias in aliases or ():
+            self._aliases[alias] = key
+
+        self._aliases.setdefault(contract_name, key)
+        return model_cls
+
+    def get(self, name_or_alias: str, version: str | None = None) -> Type[BaseContract]:
+        """Retrieve a registered contract by name or alias."""
+
+        key = self._resolve_key(name_or_alias, version)
+        try:
+            return self._contracts[key]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"Unknown contract: {name_or_alias} (v{key[1]})") from exc
+
+    def items(self) -> Sequence[Tuple[Tuple[str, str], Type[BaseContract]]]:
+        """Return the registered contract mappings."""
+
+        return tuple(self._contracts.items())
+
+    def _resolve_key(self, name_or_alias: str, version: str | None) -> Tuple[str, str]:
+        if name_or_alias in self._aliases:
+            alias_name, alias_version = self._aliases[name_or_alias]
+            if version is None:
+                return alias_name, alias_version
+            return alias_name, version
+
+        contract_name = name_or_alias
+        resolved_version = version or self._default_versions.get(contract_name)
+        if resolved_version is None:
+            raise KeyError(f"No version registered for contract '{contract_name}'")
+        return contract_name, resolved_version
+
+
+registry = ContractRegistry()
+
+
+def register_contract(
+    *,
+    name: str,
+    version: str = DEFAULT_VERSION,
+    aliases: Iterable[str] | None = None,
+):
+    """Decorator to register a contract class with the registry."""
+
+    def decorator(model_cls: Type[ContractT]) -> Type[ContractT]:
+        return registry.register(model_cls, name=name, version=version, aliases=aliases)
+
+    return decorator
+

--- a/core/contracts/transforms.py
+++ b/core/contracts/transforms.py
@@ -1,0 +1,99 @@
+"""Normalization transforms for contract payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Literal, Tuple
+
+
+TransformType = Literal[
+    "rename_field",
+    "coerce_type",
+    "default_if_missing",
+    "strip_whitespace",
+    "clamp_list_len",
+]
+
+
+@dataclass(frozen=True)
+class Transform:
+    """A normalization instruction applied to payload dictionaries."""
+
+    type: TransformType
+    from_field: str | None = None
+    to_field: str | None = None
+    field: str | None = None
+    target_type: type | None = None
+    default: Any = None
+    max_len: int | None = None
+
+
+def apply_transforms(payload: Dict[str, Any], rules: Iterable[Transform]) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Apply normalization transforms to a payload dictionary."""
+
+    transformed = dict(payload)
+    log: List[Dict[str, Any]] = []
+
+    for rule in rules:
+        if rule.type == "rename_field":
+            from_field = rule.from_field
+            to_field = rule.to_field
+            if not from_field or not to_field or from_field not in transformed:
+                continue
+            value = transformed.pop(from_field)
+            if to_field not in transformed:
+                transformed[to_field] = value
+                log.append({"rule": "rename_field", "from": from_field, "to": to_field})
+            else:
+                transformed[to_field] = transformed[to_field]
+        elif rule.type == "coerce_type":
+            field = rule.field
+            target_type = rule.target_type
+            if not field or target_type is None or field not in transformed:
+                continue
+            value = transformed[field]
+            try:
+                transformed[field] = target_type(value)
+                log.append({"rule": "coerce_type", "field": field, "type": target_type.__name__})
+            except (TypeError, ValueError):
+                log.append({"rule": "coerce_type", "field": field, "type": target_type.__name__, "error": "conversion_failed"})
+        elif rule.type == "default_if_missing":
+            field = rule.field
+            if not field or field in transformed:
+                continue
+            transformed[field] = rule.default
+            log.append({"rule": "default_if_missing", "field": field, "value": rule.default})
+        elif rule.type == "strip_whitespace":
+            field = rule.field
+            if not field or field not in transformed:
+                continue
+            value = transformed[field]
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped != value:
+                    transformed[field] = stripped
+                    log.append({"rule": "strip_whitespace", "field": field})
+        elif rule.type == "clamp_list_len":
+            field = rule.field
+            max_len = rule.max_len
+            if not field or max_len is None or field not in transformed:
+                continue
+            value = transformed[field]
+            if isinstance(value, list) and len(value) > max_len:
+                transformed[field] = value[:max_len]
+                log.append({"rule": "clamp_list_len", "field": field, "max_len": max_len})
+
+    return transformed, log
+
+
+DEFAULT_TRANSFORMS: Dict[str, List[Transform]] = {
+    "WorkOrder": [
+        Transform(type="rename_field", from_field="depends_on", to_field="dependencies"),
+        Transform(type="strip_whitespace", field="title"),
+        Transform(type="strip_whitespace", field="objective"),
+    ],
+    "CoderResult": [],
+    "ValidationReport": [],
+    "StepStatusPayload": [],
+}
+

--- a/core/contracts/validation_report.py
+++ b/core/contracts/validation_report.py
@@ -1,0 +1,34 @@
+"""Validation report contract."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .base import BaseContract
+from .registry import register_contract
+from .version import DEFAULT_VERSION
+
+
+class Issue(BaseModel):
+    """Validation issue description."""
+
+    model_config = ConfigDict(extra="forbid", frozen=False, ser_json_inf_nan=False)
+
+    code: str
+    file: Optional[str] = None
+    line: Optional[int] = None
+    msg: str
+
+
+@register_contract(name="ValidationReport", version=DEFAULT_VERSION, aliases=["validation_report"])
+class ValidationReport(BaseContract):
+    """Validator output surface."""
+
+    step_id: UUID
+    fatal: List[Issue] = Field(default_factory=list)
+    warnings: List[Issue] = Field(default_factory=list)
+    metrics: Dict[str, Any] = Field(default_factory=dict)
+

--- a/core/contracts/version.py
+++ b/core/contracts/version.py
@@ -1,0 +1,5 @@
+"""Contract versioning constants."""
+
+DEFAULT_VERSION = "1.0.0"
+SCHEMA_NS = "io.app.contracts"
+

--- a/core/contracts/work_order.py
+++ b/core/contracts/work_order.py
@@ -1,0 +1,27 @@
+"""WorkOrder contract models."""
+
+from __future__ import annotations
+
+from typing import List, Literal
+from uuid import UUID
+
+from pydantic import Field
+
+from .base import BaseContract
+from .registry import register_contract
+from .version import DEFAULT_VERSION
+
+
+@register_contract(name="WorkOrder", version=DEFAULT_VERSION, aliases=["work_order"])
+class WorkOrder(BaseContract):
+    """Canonical work order payload."""
+
+    work_order_id: UUID
+    title: str
+    objective: str
+    constraints: List[str] = Field(default_factory=list)
+    acceptance_criteria: List[str] = Field(default_factory=list)
+    context_files: List[str] = Field(default_factory=list)
+    dependencies: List[str] = Field(default_factory=list)
+    return_format: Literal["unified-diff"]
+

--- a/scripts/print_contract_schemas.py
+++ b/scripts/print_contract_schemas.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Print JSON schemas for all registered contract models."""
+
+from __future__ import annotations
+
+import json
+
+from core.contracts import registry
+
+
+def main() -> None:
+    contracts = sorted(registry.items(), key=lambda item: item[0])
+    for (name, version), model_cls in contracts:
+        schema = model_cls.model_json_schema()
+        print(f"# {name} v{version}")
+        print(json.dumps(schema, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/unit/contracts/test_contracts_models.py
+++ b/tests/unit/contracts/test_contracts_models.py
@@ -1,0 +1,59 @@
+"""Tests for contract models."""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from core.contracts import Issue, ValidationReport, WorkOrder
+from core.contracts.version import DEFAULT_VERSION, SCHEMA_NS
+
+
+def _work_order_payload() -> dict:
+    return {
+        "work_order_id": uuid4(),
+        "title": "  Build feature  ",
+        "objective": "  Ship clean diff  ",
+        "constraints": ["no deps"],
+        "acceptance_criteria": ["tests pass"],
+        "context_files": ["README.md"],
+        "return_format": "unified-diff",
+    }
+
+
+def test_work_order_rejects_extra_fields() -> None:
+    payload = _work_order_payload()
+    payload["unexpected"] = "nope"
+
+    with pytest.raises(ValidationError):
+        WorkOrder(**payload)
+
+
+def test_work_order_serialization_and_schema_fields() -> None:
+    work_order = WorkOrder(**_work_order_payload())
+
+    assert work_order.schema_version == DEFAULT_VERSION
+    assert work_order.schema_id == f"{SCHEMA_NS}/WorkOrder/{DEFAULT_VERSION}"
+
+    serialized = work_order.to_dict()
+    assert serialized["schema_version"] == DEFAULT_VERSION
+    assert json.loads(work_order.to_json())["schema_id"] == work_order.schema_id
+
+    schema = json.loads(WorkOrder.schema_json())
+    assert schema["$id"].endswith(f"/WorkOrder/{DEFAULT_VERSION}")
+
+
+def test_validation_report_nested_model() -> None:
+    report = ValidationReport(
+        step_id=uuid4(),
+        fatal=[Issue(code="ERR", file="file.py", line=3, msg="boom")],
+        warnings=[Issue(code="WARN", file=None, line=None, msg="careful")],
+        metrics={"tests_run": 3},
+    )
+
+    assert report.fatal[0].code == "ERR"
+    assert report.metrics["tests_run"] == 3
+

--- a/tests/unit/contracts/test_contracts_registry.py
+++ b/tests/unit/contracts/test_contracts_registry.py
@@ -1,0 +1,36 @@
+"""Tests for the contract registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.contracts import BaseContract, registry
+from core.contracts.registry import register_contract
+from core.contracts.version import DEFAULT_VERSION
+
+
+def test_registry_lookup_by_name_and_alias() -> None:
+    work_order_cls = registry.get("WorkOrder")
+    assert issubclass(work_order_cls, BaseContract)
+
+    from_alias = registry.get("work_order")
+    assert from_alias is work_order_cls
+
+
+def test_registry_unknown_contract_raises() -> None:
+    with pytest.raises(KeyError):
+        registry.get("unknown_contract")
+
+
+def test_registry_registers_new_contract_with_alias() -> None:
+
+    @register_contract(name="DemoContract", aliases=["demo"])
+    class DemoContract(BaseContract):
+        value: str
+
+    retrieved = registry.get("DemoContract", version=DEFAULT_VERSION)
+    assert retrieved is DemoContract
+
+    alias_lookup = registry.get("demo")
+    assert alias_lookup is DemoContract
+

--- a/tests/unit/contracts/test_contracts_transforms.py
+++ b/tests/unit/contracts/test_contracts_transforms.py
@@ -1,0 +1,32 @@
+"""Tests for contract normalization transforms."""
+
+from __future__ import annotations
+
+from core.contracts.transforms import DEFAULT_TRANSFORMS, Transform, apply_transforms
+
+
+def test_work_order_default_transforms_applied() -> None:
+    payload = {
+        "depends_on": ["step-1"],
+        "title": "  Implement feature  ",
+        "objective": "Ship diff",
+    }
+
+    transformed, log = apply_transforms(payload, DEFAULT_TRANSFORMS["WorkOrder"])
+
+    assert "depends_on" not in transformed
+    assert transformed["dependencies"] == ["step-1"]
+    assert transformed["title"] == "Implement feature"
+    assert any(entry["rule"] == "rename_field" for entry in log)
+    assert any(entry["rule"] == "strip_whitespace" for entry in log)
+
+
+def test_clamp_list_transform() -> None:
+    rules = [Transform(type="clamp_list_len", field="items", max_len=2)]
+    payload = {"items": [1, 2, 3]}
+
+    transformed, log = apply_transforms(payload, rules)
+
+    assert transformed["items"] == [1, 2]
+    assert log == [{"rule": "clamp_list_len", "field": "items", "max_len": 2}]
+


### PR DESCRIPTION
## Summary
- add a shared BaseContract with version helpers and implement canonical contracts
- provide a registry, step/output mapping data, and normalization transforms
- add schema export tooling plus unit coverage for models, registry, and transforms

## Testing
- pytest tests/unit/contracts -q *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68dbb5f5eaf483318d7e153f03867d04