### PR TITLE
feat: add github integrator skeleton

### DIFF
--- a/backend/agents/github/__init__.py
+++ b/backend/agents/github/__init__.py
@@ -1,1 +1,17 @@
 """GitHub agent package."""
+from .config import GitHubConfig
+from .errors import GitHubError, PatchApplyError
+from .github_client import GitHubClient, PatchSummary, validate_branch_name, validate_unified_diff
+from .pr_body import render_pr_body, render_step_update
+
+__all__ = [
+    "GitHubClient",
+    "GitHubConfig",
+    "GitHubError",
+    "PatchApplyError",
+    "PatchSummary",
+    "render_pr_body",
+    "render_step_update",
+    "validate_branch_name",
+    "validate_unified_diff",
+]

--- a/backend/agents/github/config.py
+++ b/backend/agents/github/config.py
@@ -1,0 +1,28 @@
+"""GitHub client configuration models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(slots=True)
+class GitHubConfig:
+    """Configuration required to connect to a GitHub App installation.
+
+    Attributes:
+        app_id: Identifier for the GitHub App.
+        installation_id: Identifier for the GitHub App installation.
+        org: Optional organization slug if the app is scoped to an org.
+        base_url: Optional base API URL for GitHub Enterprise deployments.
+        repo: Target repository in the format ``"owner/name"``.
+        base_ref: Branch that new feature branches should fork from.
+        allow_auto_merge: Feature flag controlling automatic merges.
+    """
+
+    app_id: str
+    installation_id: str
+    org: Optional[str] = None
+    base_url: Optional[str] = None
+    repo: str = ""
+    base_ref: str = ""
+    allow_auto_merge: bool = False

--- a/backend/agents/github/errors.py
+++ b/backend/agents/github/errors.py
@@ -1,0 +1,23 @@
+"""GitHub client exceptions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(slots=True)
+class GitHubError(Exception):
+    """Base exception for GitHub client operations."""
+
+    message: str
+    meta: Optional[Dict[str, Any]] = None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.message
+
+
+@dataclass(slots=True)
+class PatchApplyError(GitHubError):
+    """Raised when a patch cannot be applied cleanly."""
+
+    failed_paths: Optional[list[str]] = None

--- a/backend/agents/github/github_client.py
+++ b/backend/agents/github/github_client.py
@@ -1,0 +1,90 @@
+"""GitHub client interfaces for the agent runtime."""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Tuple
+
+from .errors import PatchApplyError
+
+LOGGER = logging.getLogger(__name__)
+
+BRANCH_NAME_PATTERN = re.compile(r"^(?!/)(?!.*//)(?!.*\.\.)[A-Za-z0-9][A-Za-z0-9._/-]{0,254}$")
+DRY_RUN = True
+
+
+@dataclass(slots=True)
+class PatchSummary:
+    """Summary describing the result of applying a patch."""
+
+    changed_files: int
+    additions: int
+    deletions: int
+
+
+def validate_unified_diff(diff: str) -> None:
+    """Ensure the provided diff is a unified diff produced by git."""
+
+    if not diff.startswith("diff --git "):
+        raise ValueError("Unified diff must start with 'diff --git '.")
+
+
+def validate_branch_name(name: str) -> None:
+    """Validate a Git reference name for safety before using it remotely."""
+
+    if not name:
+        raise ValueError("Branch name must be provided.")
+    if not BRANCH_NAME_PATTERN.match(name):
+        raise ValueError("Branch name contains unsupported characters or structure.")
+
+
+class GitHubClient:
+    """Interface for GitHub operations required by the orchestrator."""
+
+    def ensure_branch(self, base_ref: str, feature_ref: str) -> None:
+        """Ensure ``feature_ref`` exists by creating it from ``base_ref`` if needed."""
+
+        validate_branch_name(base_ref)
+        validate_branch_name(feature_ref)
+        LOGGER.info("ensure_branch", extra={"base_ref": base_ref, "feature_ref": feature_ref})
+        if not DRY_RUN:
+            raise NotImplementedError
+
+    def apply_patch(self, feature_ref: str, unified_diff: str) -> PatchSummary:
+        """Apply a unified diff onto ``feature_ref`` and return a summary."""
+
+        validate_branch_name(feature_ref)
+        validate_unified_diff(unified_diff)
+        LOGGER.info("apply_patch", extra={"feature_ref": feature_ref})
+        if DRY_RUN:
+            # Deterministic placeholder summary until real integration is wired.
+            return PatchSummary(changed_files=0, additions=0, deletions=0)
+        raise PatchApplyError("Patch application not implemented.")
+
+    def create_or_update_pr(self, title: str, body_md: str, head: str, base: str) -> Tuple[int, str]:
+        """Create or update a pull request and return the PR number and URL."""
+
+        validate_branch_name(head)
+        validate_branch_name(base)
+        LOGGER.info(
+            "create_or_update_pr",
+            extra={"title": title, "head": head, "base": base, "body_length": len(body_md)},
+        )
+        if DRY_RUN:
+            return 0, "https://example.invalid/pull/0"
+        raise NotImplementedError
+
+    def update_pr_body(self, pr_number: int, body_md: str) -> None:
+        """Update the body of an existing pull request."""
+
+        LOGGER.info("update_pr_body", extra={"pr_number": pr_number, "body_length": len(body_md)})
+        if not DRY_RUN:
+            raise NotImplementedError
+
+    def post_comment(self, pr_number: int, body_md: str) -> None:
+        """Post a comment on a pull request."""
+
+        LOGGER.info("post_comment", extra={"pr_number": pr_number, "body_length": len(body_md)})
+        if not DRY_RUN:
+            raise NotImplementedError

--- a/backend/agents/github/pr_body.py
+++ b/backend/agents/github/pr_body.py
@@ -1,0 +1,72 @@
+"""Deterministic renderers for GitHub pull request bodies."""
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+
+def _format_metrics(metrics: Mapping[str, object]) -> Iterable[str]:
+    for key, value in metrics.items():
+        yield f"- {key}: {value}"
+
+
+def render_pr_body(
+    run_id: str,
+    steps_summary: Sequence[str],
+    validation_summary: str,
+    metrics: Mapping[str, object],
+) -> str:
+    """Render the full pull request body used by the orchestrator."""
+
+    lines: list[str] = ["## Summary", f"- Run ID: `{run_id}`"]
+    if steps_summary:
+        lines.extend(f"- {item}" for item in steps_summary)
+
+    lines.extend(["", "## Changes"])
+    if steps_summary:
+        lines.extend(f"- {item}" for item in steps_summary)
+    else:
+        lines.append("- Pending step execution")
+
+    lines.extend(["", "## Validation", validation_summary or "Pending validation results."])
+
+    lines.extend(["", "## Metrics"])
+    if metrics:
+        lines.extend(_format_metrics(metrics))
+    else:
+        lines.append("- No metrics reported")
+
+    lines.extend(["", "## Links", f"- Run: {run_id}", "- Artifacts: attached to run"])
+
+    return "\n".join(lines)
+
+
+def render_step_update(
+    step_index: int,
+    title: str,
+    acceptance_criteria: Sequence[str],
+    validator_results: Mapping[str, Mapping[str, object] | str],
+) -> str:
+    """Render a markdown snippet summarizing an individual step update."""
+
+    lines: list[str] = [f"### Step {step_index}: {title}", "", "**Acceptance Criteria**"]
+    if acceptance_criteria:
+        lines.extend(f"- {item}" for item in acceptance_criteria)
+    else:
+        lines.append("- No acceptance criteria supplied")
+
+    lines.extend(["", "**Validator Results**"])
+    if validator_results:
+        for name, result in validator_results.items():
+            if isinstance(result, Mapping):
+                status = result.get("status", "unknown")
+                summary = result.get("summary")
+                line = f"- {name}: {status}"
+                if summary:
+                    line += f" – {summary}"
+            else:
+                line = f"- {name}: {result}"
+            lines.append(line)
+    else:
+        lines.append("- No validators executed")
+
+    return "\n".join(lines)

--- a/tests/unit/github/test_github_client_api.py
+++ b/tests/unit/github/test_github_client_api.py
@@ -1,0 +1,43 @@
+"""Tests for the GitHub client interface skeleton."""
+from backend.agents.github.github_client import (
+    GitHubClient,
+    PatchSummary,
+    validate_branch_name,
+    validate_unified_diff,
+)
+
+import pytest
+
+
+def test_client_methods_execute_in_dry_run() -> None:
+    client = GitHubClient()
+    client.ensure_branch("main", "feat/bootstrap")
+    summary = client.apply_patch("feat/bootstrap", "diff --git a/file b/file")
+    assert isinstance(summary, PatchSummary)
+    assert summary == PatchSummary(changed_files=0, additions=0, deletions=0)
+
+    pr_number, pr_url = client.create_or_update_pr(
+        title="Bootstrap",
+        body_md="body",
+        head="feat/bootstrap",
+        base="main",
+    )
+    assert pr_number == 0
+    assert pr_url.endswith("/pull/0")
+
+    client.update_pr_body(pr_number=0, body_md="updated body")
+    client.post_comment(pr_number=0, body_md="comment")
+
+
+def test_branch_validation_rejects_unsafe_names() -> None:
+    validate_branch_name("feat/valid-branch")
+    with pytest.raises(ValueError):
+        validate_branch_name("invalid branch name")
+    with pytest.raises(ValueError):
+        validate_branch_name("../etc/passwd")
+
+
+def test_unified_diff_validation() -> None:
+    validate_unified_diff("diff --git a/file b/file")
+    with pytest.raises(ValueError):
+        validate_unified_diff("--- invalid diff")

--- a/tests/unit/github/test_pr_body.py
+++ b/tests/unit/github/test_pr_body.py
@@ -1,0 +1,38 @@
+"""Tests for PR body rendering utilities."""
+from backend.agents.github.pr_body import render_pr_body, render_step_update
+
+
+def test_render_pr_body_includes_required_sections() -> None:
+    body = render_pr_body(
+        run_id="run-123",
+        steps_summary=["Implemented feature branch scaffold"],
+        validation_summary="All validators passed.",
+        metrics={"tests": "0 failed", "lint": "clean"},
+    )
+
+    assert "## Summary" in body
+    assert "## Changes" in body
+    assert "## Validation" in body
+    assert "## Metrics" in body
+    assert "## Links" in body
+    assert "- Run ID: `run-123`" in body
+    assert "- Implemented feature branch scaffold" in body
+    assert "- tests: 0 failed" in body
+
+
+def test_render_step_update_lists_acceptance_criteria_and_validators() -> None:
+    snippet = render_step_update(
+        step_index=1,
+        title="Bootstrap integrator",
+        acceptance_criteria=["Branch created", "Patch applied"],
+        validator_results={
+            "ruff": {"status": "passed", "summary": "0 warnings"},
+            "mypy": "skipped",
+        },
+    )
+
+    assert "### Step 1: Bootstrap integrator" in snippet
+    assert "- Branch created" in snippet
+    assert "- Patch applied" in snippet
+    assert "- ruff: passed – 0 warnings" in snippet
+    assert "- mypy: skipped" in snippet


### PR DESCRIPTION
## Summary
- add configuration, client, and error primitives for the GitHub integrator skeleton
- implement deterministic pull request body renderers for orchestrator updates
- cover the new surfaces with unit tests for API contracts and markdown output

## Testing
- python -m pytest tests/unit/github

------
https://chatgpt.com/codex/tasks/task_e_68dbbe234fe4833188e6163766b05f76