### PR TITLE
feat: add deterministic planner and coder adapters

### DIFF
--- a/backend/agents/coder/coder_adapter.py
+++ b/backend/agents/coder/coder_adapter.py
@@ -1,0 +1,38 @@
+"""Coder adapter interface and helpers."""
+
+from __future__ import annotations
+
+from typing import Mapping, Protocol
+
+from core.contracts.coder_result import CoderResult
+from core.contracts.work_order import WorkOrder
+
+from . import prompt_templates
+
+
+class CoderAdapter(Protocol):
+    """Interface for coder backends."""
+
+    def execute(self, work_order: WorkOrder) -> CoderResult:
+        """Execute ``work_order`` and return the resulting diff."""
+
+    def build_coder_prompt(
+        self, work_order: WorkOrder, repo_meta: Mapping[str, object] | None = None
+    ) -> str:
+        """Return the deterministic prompt for ``work_order``."""
+
+
+class BaseCoderAdapter:
+    """Base class implementing shared prompt helpers."""
+
+    def execute(self, work_order: WorkOrder) -> CoderResult:
+        """Execute the work order using a concrete coder backend."""
+
+        raise NotImplementedError("Coder execution is not implemented in the base class")
+
+    def build_coder_prompt(
+        self, work_order: WorkOrder, repo_meta: Mapping[str, object] | None = None
+    ) -> str:
+        """Build the deterministic coder prompt for ``work_order``."""
+
+        return prompt_templates.build_coder_prompt(work_order, repo_meta)

--- a/backend/agents/coder/diff_utils.py
+++ b/backend/agents/coder/diff_utils.py
@@ -1,0 +1,82 @@
+"""Utilities for working with unified diffs."""
+
+from __future__ import annotations
+
+
+def is_unified_diff(text: str) -> bool:
+    """Return ``True`` when ``text`` looks like a ``diff --git`` payload."""
+
+    if not text:
+        return False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        return stripped.startswith("diff --git ")
+    return False
+
+
+def summarize_unified_diff(text: str) -> dict[str, int]:
+    """Return a light summary similar to ``git diff --numstat``."""
+
+    changed_files: set[str] = set()
+    additions = 0
+    deletions = 0
+
+    current_file: str | None = None
+
+    for line in text.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split()
+            if len(parts) >= 4:
+                current_file = parts[3][2:]
+                changed_files.add(current_file)
+            continue
+        if line.startswith("+++"):
+            if line.startswith("+++ b/"):
+                current_file = line[6:]
+                changed_files.add(current_file)
+            continue
+        if line.startswith("--- "):
+            continue
+        if line.startswith("@@"):
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            additions += 1
+            continue
+        if line.startswith("-") and not line.startswith("---"):
+            deletions += 1
+            continue
+        if line.startswith("new file mode") and current_file:
+            changed_files.add(current_file)
+
+    return {
+        "changed_files": len(changed_files),
+        "additions": additions,
+        "deletions": deletions,
+    }
+
+
+def find_new_files(text: str) -> list[str]:
+    """Return a list of repo-relative paths that are new in the diff."""
+
+    new_files: list[str] = []
+    pending_new: str | None = None
+    for line in text.splitlines():
+        if line.startswith("diff --git "):
+            pending_new = None
+        if line.startswith("--- /dev/null"):
+            pending_new = ""
+            continue
+        if line.startswith("+++ b/"):
+            path = line[6:]
+            if pending_new is not None:
+                if path not in new_files:
+                    new_files.append(path)
+                pending_new = None
+            continue
+        if line.startswith("new file mode"):
+            if pending_new and pending_new not in new_files:
+                new_files.append(pending_new)
+            pending_new = None
+    return new_files

--- a/backend/agents/coder/prompt_templates.py
+++ b/backend/agents/coder/prompt_templates.py
@@ -1,0 +1,92 @@
+"""Deterministic prompt builders for the coder agent."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from core.contracts.work_order import WorkOrder
+
+
+def _ensure_sequence(values: Sequence[str] | None) -> list[str]:
+    if not values:
+        return []
+    normalized: list[str] = []
+    for value in values:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                normalized.append(stripped)
+    return normalized
+
+
+def _format_list(items: Sequence[str], prefix: str) -> list[str]:
+    return [f"{prefix}{item}" for item in items]
+
+
+def build_coder_prompt(
+    work_order: WorkOrder,
+    repo_meta: Mapping[str, object] | None = None,
+) -> str:
+    """Return the deterministic prompt for GPT-5-Codex."""
+
+    constraints = _ensure_sequence(work_order.constraints)
+    criteria = _ensure_sequence(work_order.acceptance_criteria)
+    context_files = _ensure_sequence(work_order.context_files)
+
+    repo_details: list[str] = []
+    if repo_meta:
+        if (name := repo_meta.get("name")):
+            repo_details.append(f"Repository: {name}")
+        if (default_branch := repo_meta.get("default_branch")):
+            repo_details.append(f"Default branch: {default_branch}")
+        if (languages := repo_meta.get("languages")):
+            repo_details.append(f"Primary languages: {languages}")
+
+    lines: list[str] = []
+    lines.append("You are GPT-5-Codex operating as an autonomous code editor.")
+    lines.append("Follow the work order exactly and keep the diff minimal and reviewable.")
+    lines.append("")
+    lines.append(f"Work Order: {work_order.title}")
+    lines.append(f"Objective: {work_order.objective}")
+
+    if repo_details:
+        lines.append("Repository Context:")
+        lines.extend(_format_list(repo_details, "  - "))
+
+    if context_files:
+        lines.append("Allowed files to modify (repo-relative):")
+        lines.extend(_format_list(context_files, "  - "))
+    else:
+        lines.append("No context files provided; inspect only files you explicitly touch.")
+
+    if constraints:
+        lines.append("Constraints (must obey):")
+        lines.extend(_format_list(constraints, "  - "))
+    else:
+        lines.append("Constraints: none beyond standard coding best practices.")
+
+    if criteria:
+        lines.append("Acceptance criteria to satisfy:")
+        lines.extend(_format_list(criteria, "  - "))
+
+    lines.append("")
+    lines.append("Diff Requirements:")
+    lines.append("  - Output ONLY a single `diff --git` unified diff.")
+    lines.append(
+        "  - Do not include explanations, notes, tests run, or any text outside the diff."
+    )
+    lines.append("  - Paths in the diff must be relative to the repository root.")
+    lines.append("  - Keep changes narrowly scoped and minimal.")
+    lines.append(
+        "  - Unless a constraint explicitly allows it, do NOT add new dependencies or"
+        " modify dependency manifests/lockfiles."
+    )
+    lines.append("  - Do not generate non-deterministic values (timestamps, UUIDs, hashes).")
+    lines.append(
+        "  - Ensure the diff applies cleanly with `git apply` and uses UTF-8 text."
+    )
+
+    lines.append("")
+    lines.append("Return exactly the diff. No surrounding markdown fences.")
+
+    return "\n".join(lines)

--- a/backend/agents/orchestrator/routing.py
+++ b/backend/agents/orchestrator/routing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Mapping, Protocol, runtime_checkable
+from typing import Mapping, Protocol, Sequence, runtime_checkable
 
 
 class WorkOrderPayload(Protocol):
@@ -47,6 +47,8 @@ class PlannerAdapter(Protocol):
 class SubPlannerAdapter(Protocol):
     """Adapter responsible for turning planner output into a concrete work order."""
 
+    transform_log: Sequence[str]
+
     def build_work_order(self, step: Mapping[str, object]) -> WorkOrderPayload:
         """Return a canonical :class:`~core.contracts.WorkOrder` for the provided ``step``."""
 
@@ -54,6 +56,11 @@ class SubPlannerAdapter(Protocol):
 @runtime_checkable
 class CoderAdapter(Protocol):
     """Adapter that executes the work order and returns coder output."""
+
+    def build_coder_prompt(
+        self, work_order: WorkOrderPayload, repo_meta: Mapping[str, object] | None = None
+    ) -> str:
+        """Return the deterministic coder prompt for ``work_order``."""
 
     def execute(self, work_order: WorkOrderPayload) -> CoderResultPayload:
         """Execute ``work_order`` and return the resulting diff and notes."""

--- a/backend/agents/planner/prompt_templates.py
+++ b/backend/agents/planner/prompt_templates.py
@@ -1,0 +1,99 @@
+"""Deterministic prompt templates for planner + sub-planner agents."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+
+def _coerce_iterable_strings(values: object) -> list[str]:
+    """Return a list of string values preserving input order."""
+
+    items: list[str] = []
+    if values is None:
+        return items
+    if isinstance(values, str):
+        candidate = values.strip()
+        if candidate:
+            items.append(candidate)
+        return items
+    if isinstance(values, Iterable):
+        for value in values:
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                items.append(text)
+    return items
+
+
+def build_planner_summary(step: Mapping[str, object]) -> str:
+    """Return a condensed summary of the normalized planning step."""
+
+    title = str(step.get("title", ""))
+    objective = str(step.get("objective", step.get("description", "")))
+    constraints = _coerce_iterable_strings(step.get("constraints"))
+    criteria = _coerce_iterable_strings(step.get("acceptance_criteria"))
+    context_files = _coerce_iterable_strings(step.get("context_files"))
+
+    lines: list[str] = []
+    lines.append("[Planner Step Summary]")
+    lines.append(f"Title: {title.strip() or 'Untitled'}")
+    lines.append(f"Objective: {objective.strip() or 'None provided'}")
+
+    if constraints:
+        lines.append("Constraints:")
+        for idx, constraint in enumerate(constraints, start=1):
+            lines.append(f"  {idx}. {constraint}")
+    else:
+        lines.append("Constraints: none specified")
+
+    if criteria:
+        lines.append("Acceptance Criteria:")
+        for idx, criterion in enumerate(criteria, start=1):
+            lines.append(f"  {idx}. {criterion}")
+    else:
+        lines.append("Acceptance Criteria: none provided")
+
+    if context_files:
+        lines.append("Context Files:")
+        for path in context_files:
+            lines.append(f"  - {path}")
+
+    return "\n".join(lines)
+
+
+def build_work_order_brief(work_order: Mapping[str, object]) -> str:
+    """Return a deterministic human readable work order summary."""
+
+    constraints = _coerce_iterable_strings(work_order.get("constraints"))
+    criteria = _coerce_iterable_strings(work_order.get("acceptance_criteria"))
+    context_files = _coerce_iterable_strings(work_order.get("context_files"))
+
+    lines: list[str] = []
+    lines.append("[Work Order Brief]")
+    lines.append(f"Title: {work_order.get('title', '')}")
+    lines.append(f"Objective: {work_order.get('objective', '')}")
+    lines.append(f"Return Format: {work_order.get('return_format', '')}")
+
+    lines.append("Constraints:")
+    if constraints:
+        for idx, constraint in enumerate(constraints, start=1):
+            lines.append(f"  {idx}. {constraint}")
+    else:
+        lines.append("  (none)")
+
+    lines.append("Acceptance Criteria:")
+    if criteria:
+        for idx, criterion in enumerate(criteria, start=1):
+            lines.append(f"  {idx}. {criterion}")
+    else:
+        lines.append("  (none)")
+
+    lines.append("Context Files:")
+    if context_files:
+        for path in context_files:
+            lines.append(f"  - {path}")
+    else:
+        lines.append("  (none)")
+
+    return "\n".join(lines)

--- a/backend/agents/planner/sub_planner_adapter.py
+++ b/backend/agents/planner/sub_planner_adapter.py
@@ -1,0 +1,148 @@
+"""Implementation of the sub-planner adapter."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+from uuid import UUID
+
+from core.contracts.work_order import WorkOrder
+
+from .prompt_templates import build_planner_summary, build_work_order_brief
+
+
+class BasicSubPlanner:
+    """Normalize planner steps into canonical :class:`WorkOrder` payloads."""
+
+    DEFAULT_DEPENDENCY_CONSTRAINT = "Do not add or modify dependencies."
+    DEFAULT_RETURN_FORMAT = "unified-diff"
+    DEFAULT_CONTEXT_ALLOWLIST: tuple[str, ...] = ("README.md", "docs/starter-spec.md")
+
+    def __init__(self) -> None:
+        self.transform_log: list[str] = []
+
+    def _log(self, message: str) -> None:
+        self.transform_log.append(message)
+
+    def _coerce_uuid(self, value: object) -> UUID:
+        if isinstance(value, UUID):
+            return value
+        if value is None:
+            raise ValueError("Work order requires a work_order_id")
+        return UUID(str(value))
+
+    def _normalize_text(self, value: object, field_name: str) -> str:
+        if value is None:
+            raise ValueError(f"Work order requires field '{field_name}'")
+        text = str(value).strip()
+        if not text:
+            raise ValueError(f"Work order field '{field_name}' cannot be empty")
+        self._log(f"Normalized {field_name} whitespace")
+        return text
+
+    def _normalize_sequence(self, value: object, field_name: str) -> list[str]:
+        items: list[str] = []
+        if value is None:
+            return items
+        if isinstance(value, str):
+            candidate = value.strip()
+            if candidate:
+                items.append(candidate)
+        elif isinstance(value, Iterable):
+            for entry in value:
+                if entry is None:
+                    continue
+                candidate = str(entry).strip()
+                if candidate:
+                    items.append(candidate)
+        else:
+            candidate = str(value).strip()
+            if candidate:
+                items.append(candidate)
+        if items:
+            self._log(f"Normalized {field_name} list")
+        return items
+
+    def _extract_context_from_hints(self, step: Mapping[str, object]) -> list[str]:
+        hints = step.get("hints")
+        files: list[str] = []
+        if isinstance(hints, Mapping):
+            for key in ("files", "context_files"):
+                hint_values = hints.get(key)
+                if isinstance(hint_values, str):
+                    candidate = hint_values.strip()
+                    if candidate:
+                        files.append(candidate)
+                elif isinstance(hint_values, Iterable):
+                    for value in hint_values:
+                        if value is None:
+                            continue
+                        candidate = str(value).strip()
+                        if candidate:
+                            files.append(candidate)
+        return files
+
+    def _select_context_files(self, step: Mapping[str, object]) -> list[str]:
+        provided = self._normalize_sequence(step.get("context_files"), "context_files")
+        hints = self._extract_context_from_hints(step)
+        selected: list[str] = []
+        for path in provided + hints:
+            if path not in selected:
+                selected.append(path)
+        if not selected:
+            selected = list(self.DEFAULT_CONTEXT_ALLOWLIST)
+            if selected:
+                self._log("Defaulted context files to allowlist")
+        else:
+            self._log("Captured context files from step input")
+        return selected
+
+    def build_work_order(self, step: Mapping[str, object]) -> WorkOrder:
+        """Return a canonical work order for ``step``."""
+
+        self.transform_log = []
+
+        work_order_id = self._coerce_uuid(
+            step.get("work_order_id") or step.get("id")
+        )
+        title = self._normalize_text(step.get("title"), "title")
+        objective = self._normalize_text(step.get("objective"), "objective")
+
+        constraints = self._normalize_sequence(step.get("constraints"), "constraints")
+        if not any(
+            self.DEFAULT_DEPENDENCY_CONSTRAINT.lower() in item.lower()
+            for item in constraints
+        ):
+            constraints.append(self.DEFAULT_DEPENDENCY_CONSTRAINT)
+            self._log("Injected default dependency constraint")
+
+        acceptance_criteria = self._normalize_sequence(
+            step.get("acceptance_criteria"), "acceptance_criteria"
+        )
+
+        context_files = self._select_context_files(step)
+
+        dependencies_allowed = bool(step.get("allow_dependency_changes"))
+        dependencies = self._normalize_sequence(step.get("dependencies"), "dependencies")
+        if not dependencies_allowed:
+            if dependencies:
+                self._log("Discarded dependency requests because they are not allowed")
+            dependencies = []
+        else:
+            self._log("Preserved explicit dependency requests")
+
+        work_order = WorkOrder(
+            work_order_id=work_order_id,
+            title=title,
+            objective=objective,
+            constraints=constraints,
+            acceptance_criteria=acceptance_criteria,
+            context_files=context_files,
+            dependencies=dependencies,
+            return_format=self.DEFAULT_RETURN_FORMAT,
+        )
+
+        self._log("Generated planner summary\n" + build_planner_summary(step))
+        self._log(
+            "Generated work order brief\n" + build_work_order_brief(work_order.to_dict())
+        )
+        return work_order

--- a/core/contracts/base.py
+++ b/core/contracts/base.py
@@ -23,7 +23,7 @@ class ModelVersion:
 class BaseContract(BaseModel):
     """Base class for all contract models."""
 
-    model_config = ConfigDict(extra="forbid", frozen=False, ser_json_inf_nan=False)
+    model_config = ConfigDict(extra="forbid", frozen=False, ser_json_inf_nan='null')
 
     schema_version: str = Field(default="")
     schema_id: str = Field(default="")

--- a/core/contracts/validation_report.py
+++ b/core/contracts/validation_report.py
@@ -15,7 +15,7 @@ from .version import DEFAULT_VERSION
 class Issue(BaseModel):
     """Validation issue description."""
 
-    model_config = ConfigDict(extra="forbid", frozen=False, ser_json_inf_nan=False)
+    model_config = ConfigDict(extra="forbid", frozen=False, ser_json_inf_nan='null')
 
     code: str
     file: Optional[str] = None

--- a/tests/unit/coder/test_coder_prompts_and_diff_detection.py
+++ b/tests/unit/coder/test_coder_prompts_and_diff_detection.py
@@ -1,0 +1,56 @@
+"""Tests for coder prompt builders and diff utilities."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from backend.agents.coder import diff_utils
+from backend.agents.coder.coder_adapter import BaseCoderAdapter
+from backend.agents.coder.prompt_templates import build_coder_prompt
+from core.contracts.work_order import WorkOrder
+
+
+class DummyCoder(BaseCoderAdapter):
+    pass
+
+
+def _make_work_order() -> WorkOrder:
+    return WorkOrder(
+        work_order_id=uuid4(),
+        title="Add login",
+        objective="Implement POST /login",
+        constraints=["Focus on auth handler", "Do not add or modify dependencies."],
+        acceptance_criteria=["Users receive JWT", "Tests pass"],
+        context_files=["backend/api/auth.py"],
+        dependencies=[],
+        return_format="unified-diff",
+    )
+
+
+def test_coder_prompt_contains_constraints_and_criteria() -> None:
+    work_order = _make_work_order()
+    prompt_one = build_coder_prompt(work_order)
+    prompt_two = DummyCoder().build_coder_prompt(work_order)
+    assert prompt_one == prompt_two
+    assert "Focus on auth handler" in prompt_one
+    assert "Users receive JWT" in prompt_one
+    assert "diff --git" in prompt_one
+    assert "Return exactly the diff" in prompt_one
+
+
+def test_is_unified_diff_and_summary() -> None:
+    diff_text = """diff --git a/backend/api/auth.py b/backend/api/auth.py\nindex 123..456 100644\n--- a/backend/api/auth.py\n+++ b/backend/api/auth.py\n@@ -1,3 +1,4 @@\n-import old\n+import new\n+added_line\n return True\n"""
+    assert diff_utils.is_unified_diff(diff_text)
+    summary = diff_utils.summarize_unified_diff(diff_text)
+    assert summary == {"changed_files": 1, "additions": 2, "deletions": 1}
+
+
+def test_find_new_files_detects_created_paths() -> None:
+    diff_text = """diff --git a/dev/null b/docs/new.md\nnew file mode 100644\nindex 0000000..1111111\n--- /dev/null\n+++ b/docs/new.md\n@@ -0,0 +1,2 @@\n+hello\n+world\n"""
+    assert diff_utils.is_unified_diff(diff_text)
+    new_files = diff_utils.find_new_files(diff_text)
+    assert new_files == ["docs/new.md"]
+
+
+def test_is_unified_diff_rejects_plain_text() -> None:
+    assert not diff_utils.is_unified_diff("print('hello world')")

--- a/tests/unit/planner/test_sub_planner_prompts.py
+++ b/tests/unit/planner/test_sub_planner_prompts.py
@@ -1,0 +1,65 @@
+"""Tests for the sub-planner prompt builders and adapter."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from backend.agents.planner.prompt_templates import (
+    build_planner_summary,
+    build_work_order_brief,
+)
+from backend.agents.planner.sub_planner_adapter import BasicSubPlanner
+
+
+def _make_step() -> dict[str, object]:
+    work_order_id = uuid4()
+    return {
+        "work_order_id": work_order_id,
+        "title": "  Implement login endpoint  ",
+        "objective": "  Create POST /login handler ",
+        "constraints": [" Focus only on auth module"],
+        "acceptance_criteria": (" Users can authenticate", " Response includes token "),
+        "context_files": ["backend/api/auth.py", " README.md  "],
+    }
+
+
+def test_planner_templates_are_deterministic() -> None:
+    step = _make_step()
+    first = build_planner_summary(step)
+    second = build_planner_summary(step)
+    assert first == second
+
+
+def test_work_order_brief_is_deterministic() -> None:
+    planner = BasicSubPlanner()
+    work_order = planner.build_work_order(_make_step())
+    brief_one = build_work_order_brief(work_order.to_dict())
+    brief_two = build_work_order_brief(work_order.to_dict())
+    assert brief_one == brief_two
+
+
+def test_basic_sub_planner_normalizes_fields() -> None:
+    planner = BasicSubPlanner()
+    step = _make_step()
+    work_order = planner.build_work_order(step)
+
+    assert work_order.title == "Implement login endpoint"
+    assert work_order.objective == "Create POST /login handler"
+    assert planner.DEFAULT_DEPENDENCY_CONSTRAINT in work_order.constraints
+    assert work_order.return_format == "unified-diff"
+    assert work_order.dependencies == []
+    assert work_order.context_files[0] == "backend/api/auth.py"
+    assert work_order.context_files[1] == "README.md"
+    assert "Normalized title whitespace" in planner.transform_log
+    assert "Generated work order brief" in "\n".join(planner.transform_log)
+
+
+def test_basic_sub_planner_defaults_context_allowlist_when_missing() -> None:
+    planner = BasicSubPlanner()
+    step = {
+        "work_order_id": uuid4(),
+        "title": "Add search",
+        "objective": "Implement search endpoint",
+    }
+    work_order = planner.build_work_order(step)
+    assert work_order.context_files == list(planner.DEFAULT_CONTEXT_ALLOWLIST)


### PR DESCRIPTION
## Summary
- add deterministic planner prompt builders and implement the BasicSubPlanner that normalizes steps into WorkOrder payloads
- build a coder adapter base with prompt templates plus unified-diff utilities for diff validation
- update orchestrator protocols/core contract config and add unit tests covering prompts and diff detection

## Testing
- pytest tests/unit/planner tests/unit/coder

------
https://chatgpt.com/codex/tasks/task_e_68dbcb2daf808331ab6c88be1cc4cab4