### PR TITLE
feat: add happy path orchestrator demo

### DIFF
--- a/backend/agents/coder/coder_adapter_fake.py
+++ b/backend/agents/coder/coder_adapter_fake.py
@@ -1,0 +1,62 @@
+"""Deterministic coder adapter used by the happy-path demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from backend.agents.orchestrator.routing import CoderAdapter
+
+_DEFAULT_DIFF_PATH = Path(__file__).resolve().parent / "diffs" / "demo_patch.txt"
+
+
+@dataclass(frozen=True)
+class DemoCoderResult:
+    """Coder result payload returned by :class:`CoderAdapterFake`."""
+
+    work_order_id: str
+    diff: str
+    notes: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a mapping suitable for persistence."""
+
+        return {"work_order_id": self.work_order_id, "diff": self.diff, "notes": self.notes}
+
+
+class CoderAdapterFake(CoderAdapter):
+    """Fake coder that returns a pre-computed unified diff."""
+
+    def __init__(self, diff_path: Path | None = None) -> None:
+        path = diff_path or _DEFAULT_DIFF_PATH
+        self._diff_text = path.read_text(encoding="utf-8").strip()
+        if not self._diff_text.startswith("diff --git "):
+            raise ValueError("Demo diff must be a unified diff starting with 'diff --git '.")
+
+    def build_coder_prompt(
+        self, work_order: Mapping[str, object] | object, repo_meta: Mapping[str, object] | None = None
+    ) -> str:
+        """Return a deterministic prompt preview for debugging."""
+
+        title = self._get_attr(work_order, "title", default="Demo Work Order")
+        objective = self._get_attr(work_order, "objective", default="")
+        return f"Implement: {title}\nObjective: {objective}"
+
+    def execute(self, work_order: Mapping[str, object] | object) -> DemoCoderResult:
+        """Return a deterministic diff for ``work_order``."""
+
+        work_order_id = str(self._get_attr(work_order, "work_order_id", default="demo-work-order"))
+        notes = "Applied canned diff for demo run"
+        return DemoCoderResult(work_order_id=work_order_id, diff=self._diff_text, notes=notes)
+
+    @staticmethod
+    def _get_attr(work_order: Mapping[str, object] | object, key: str, *, default: object) -> object:
+        """Retrieve ``key`` from ``work_order`` handling mappings and dataclasses."""
+
+        if isinstance(work_order, Mapping):
+            return work_order.get(key, default)
+        return getattr(work_order, key, default)
+
+
+__all__ = ["CoderAdapterFake", "DemoCoderResult"]

--- a/backend/agents/coder/diffs/demo_patch.txt
+++ b/backend/agents/coder/diffs/demo_patch.txt
@@ -1,0 +1,18 @@
+diff --git a/frontend/app/settings.tsx b/frontend/app/settings.tsx
+new file mode 100644
+index 0000000..1a2b3c4
+--- /dev/null
++++ b/frontend/app/settings.tsx
+@@
++import React from "react";
++
++export function SettingsPage(): JSX.Element {
++  return (
++    <main className="p-6 space-y-4">
++      <h1 className="text-2xl font-semibold">Settings</h1>
++      <p className="text-sm text-slate-600">
++        Configure your workspace preferences from this placeholder screen.
++      </p>
++    </main>
++  );
++}

--- a/backend/agents/github/github_client_fake.py
+++ b/backend/agents/github/github_client_fake.py
@@ -1,0 +1,111 @@
+"""Deterministic GitHub client fake for the happy-path demo."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Mapping, Tuple
+
+from backend.agents.github.github_client import validate_branch_name, validate_unified_diff
+from backend.agents.orchestrator.routing import GitHubClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DryRunPatchSummary:
+    """Patch summary that mirrors :class:`PatchSummary` for coercion."""
+
+    changed_files: int
+    additions: int
+    deletions: int
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a mapping representation for persistence."""
+
+        return {
+            "changed_files": self.changed_files,
+            "additions": self.additions,
+            "deletions": self.deletions,
+        }
+
+
+class GitHubClientFake(GitHubClient):
+    """GitHub client fake that records intentions without network access."""
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or LOGGER
+        self.ensure_calls: list[Tuple[str, str]] = []
+        self.patch_calls: list[Tuple[str, str]] = []
+        self.pr_calls: list[Tuple[str, str, str, str]] = []
+        self.update_calls: list[Tuple[int, str]] = []
+        self.comment_calls: list[Tuple[int, str]] = []
+
+    def ensure_branch(self, base_ref: str, feature_ref: str) -> None:
+        """Record an intent to ensure the feature branch exists."""
+
+        validate_branch_name(base_ref)
+        validate_branch_name(feature_ref)
+        self.ensure_calls.append((base_ref, feature_ref))
+        self._logger.info("github.ensure_branch", extra={"base_ref": base_ref, "feature_ref": feature_ref})
+
+    def apply_patch(self, feature_ref: str, unified_diff: str) -> DryRunPatchSummary:
+        """Validate the diff and return a deterministic patch summary."""
+
+        validate_branch_name(feature_ref)
+        validate_unified_diff(unified_diff)
+        self.patch_calls.append((feature_ref, unified_diff))
+        additions = self._count_lines(unified_diff, prefix="+")
+        deletions = self._count_lines(unified_diff, prefix="-")
+        summary = DryRunPatchSummary(changed_files=1, additions=additions, deletions=deletions)
+        self._logger.info(
+            "github.apply_patch",
+            extra={"feature_ref": feature_ref, "additions": additions, "deletions": deletions},
+        )
+        return summary
+
+    def create_or_update_pr(self, title: str, body_md: str, head: str, base: str) -> Tuple[int, str]:
+        """Return a canned PR identifier without performing network calls."""
+
+        validate_branch_name(head)
+        validate_branch_name(base)
+        self.pr_calls.append((title, body_md, head, base))
+        self._logger.info(
+            "github.create_pr",
+            extra={"title": title, "head": head, "base": base, "body_length": len(body_md)},
+        )
+        return 123, "https://example.test/pr/123"
+
+    def update_pr_body(self, pr_number: int, body_md: str) -> None:
+        """Record body updates for observability in tests and demo output."""
+
+        self.update_calls.append((pr_number, body_md))
+        self._logger.info(
+            "github.update_pr_body", extra={"pr_number": pr_number, "body_length": len(body_md)}
+        )
+
+    def post_comment(self, pr_number: int, body_md: str) -> None:
+        """Record pull request comments for completeness."""
+
+        self.comment_calls.append((pr_number, body_md))
+        self._logger.info(
+            "github.post_comment", extra={"pr_number": pr_number, "body_length": len(body_md)}
+        )
+
+    def _count_lines(self, diff: str, *, prefix: str) -> int:
+        """Count diff lines beginning with ``prefix`` excluding headers."""
+
+        total = 0
+        for line in diff.splitlines():
+            if not line or line.startswith("diff --git "):
+                continue
+            if prefix == "+" and line.startswith("+++"):
+                continue
+            if prefix == "-" and line.startswith("---"):
+                continue
+            if line.startswith(prefix):
+                total += 1
+        return total
+
+
+__all__ = ["DryRunPatchSummary", "GitHubClientFake"]

--- a/backend/agents/orchestrator/wiring_demo.py
+++ b/backend/agents/orchestrator/wiring_demo.py
@@ -1,0 +1,97 @@
+"""Factory helpers that wire the orchestrator with in-memory fakes for demos."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Mapping
+
+from backend.agents.coder.coder_adapter_fake import CoderAdapterFake
+from backend.agents.github.github_client_fake import GitHubClientFake
+from backend.agents.orchestrator.orchestrator_agent import OrchestratorAgent
+from backend.agents.planner.sub_planner_adapter_fake import SubPlannerAdapterFake
+from backend.agents.validator.fake_validator import FakeValidator
+from core.events.capture import InMemoryEventsPublisher
+from core.store.memory_repos import (
+    InMemoryArtifactRepo,
+    InMemoryPRBindingRepo,
+    InMemoryRunRepo,
+    InMemoryStepRepo,
+    InMemoryValidationReportRepo,
+)
+
+
+@dataclass(slots=True)
+class DemoOrchestratorContext:
+    """Container returned by :func:`build_demo_orchestrator`."""
+
+    orchestrator: OrchestratorAgent
+    run_repo: InMemoryRunRepo
+    step_repo: InMemoryStepRepo
+    artifact_repo: InMemoryArtifactRepo
+    report_repo: InMemoryValidationReportRepo
+    pr_repo: InMemoryPRBindingRepo
+    events: InMemoryEventsPublisher
+
+
+class PlannerPassthrough:
+    """Minimal planner adapter that echoes step metadata.
+
+    The production orchestrator expects a planner adapter, but the happy
+    path demo focuses on exercising the sub-planner → coder → validator
+    pipeline. This passthrough preserves input structure so the fake
+    sub-planner can normalise the payload deterministically.
+    """
+
+    def plan_step(self, step: Mapping[str, object]) -> Mapping[str, object]:
+        """Return a shallow copy of ``step`` to satisfy the protocol."""
+
+        return dict(step)
+
+
+def build_demo_orchestrator(*, config: Mapping[str, object] | None = None) -> DemoOrchestratorContext:
+    """Return an :class:`OrchestratorAgent` wired against in-memory fakes."""
+
+    run_repo = InMemoryRunRepo()
+    step_repo = InMemoryStepRepo()
+    artifact_repo = InMemoryArtifactRepo()
+    report_repo = InMemoryValidationReportRepo()
+    pr_repo = InMemoryPRBindingRepo()
+    events = InMemoryEventsPublisher()
+
+    planner = PlannerPassthrough()
+    sub_planner = SubPlannerAdapterFake()
+    coder = CoderAdapterFake()
+    validator = FakeValidator()
+    github = GitHubClientFake()
+
+    logger = logging.getLogger("demo.orchestrator")
+
+    orchestrator = OrchestratorAgent(
+        run_repo=run_repo,
+        step_repo=step_repo,
+        artifact_repo=artifact_repo,
+        report_repo=report_repo,
+        pr_repo=pr_repo,
+        planner_adapter=planner,
+        sub_planner_adapter=sub_planner,
+        coder_adapter=coder,
+        validator_service=validator,
+        github_client=github,
+        events=events,
+        logger=logger,
+        config=config or {"feature_branch": "demo/happy-path"},
+    )
+
+    return DemoOrchestratorContext(
+        orchestrator=orchestrator,
+        run_repo=run_repo,
+        step_repo=step_repo,
+        artifact_repo=artifact_repo,
+        report_repo=report_repo,
+        pr_repo=pr_repo,
+        events=events,
+    )
+
+
+__all__ = ["DemoOrchestratorContext", "build_demo_orchestrator"]

--- a/backend/agents/planner/sub_planner_adapter_fake.py
+++ b/backend/agents/planner/sub_planner_adapter_fake.py
@@ -1,0 +1,121 @@
+"""Deterministic fake sub-planner for the happy-path demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Mapping, MutableMapping
+from uuid import UUID, uuid5
+
+from backend.agents.orchestrator.routing import SubPlannerAdapter
+
+_NAMESPACE = UUID("12345678-1234-5678-1234-567812345678")
+
+
+@dataclass(frozen=True)
+class DemoWorkOrder:
+    """Minimal work-order payload returned by :class:`SubPlannerAdapterFake`."""
+
+    work_order_id: str
+    title: str
+    objective: str
+    constraints: List[str]
+    acceptance_criteria: List[str]
+    context_files: List[str]
+    return_format: str
+    metadata: Mapping[str, object]
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a serialisable representation consumed by repositories."""
+
+        return {
+            "work_order_id": self.work_order_id,
+            "title": self.title,
+            "objective": self.objective,
+            "constraints": list(self.constraints),
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "context_files": list(self.context_files),
+            "return_format": self.return_format,
+            "metadata": dict(self.metadata),
+        }
+
+
+class SubPlannerAdapterFake(SubPlannerAdapter):
+    """Fake sub-planner that normalises step text deterministically."""
+
+    def __init__(self) -> None:
+        self.transform_log: List[str] = []
+
+    def build_work_order(self, step: Mapping[str, object]) -> DemoWorkOrder:
+        """Return a deterministic :class:`DemoWorkOrder` for ``step``."""
+
+        self.transform_log = []
+        step_id = str(step.get("id") or "demo-step")
+        work_order_id = str(uuid5(_NAMESPACE, step_id))
+        title = self._normalize_text(step.get("title"), field_name="title")
+        objective = self._normalize_text(step.get("body"), field_name="body")
+
+        constraints = self._normalize_sequence(step.get("constraints"), default="Return a unified diff")
+        acceptance = self._normalize_sequence(step.get("acceptance_criteria"), default="Diff applies cleanly")
+        context_files = self._normalize_sequence(step.get("context_files"), default="README.md")
+
+        metadata: MutableMapping[str, object] = {"transform_log": list(self.transform_log)}
+
+        return DemoWorkOrder(
+            work_order_id=work_order_id,
+            title=title,
+            objective=objective,
+            constraints=constraints,
+            acceptance_criteria=acceptance,
+            context_files=context_files,
+            return_format="unified-diff",
+            metadata=metadata,
+        )
+
+    def _normalize_text(self, value: object | None, *, field_name: str) -> str:
+        """Trim whitespace while recording why normalisation occurred."""
+
+        text = (str(value or "")).strip()
+        if not text:
+            self.transform_log.append(f"Defaulted missing {field_name}")
+            return f"Demo {field_name.capitalize()}"
+        if value != text:
+            self.transform_log.append(f"Trimmed {field_name} whitespace")
+        return text
+
+    def _normalize_sequence(self, value: object | None, *, default: str) -> List[str]:
+        """Return a list of normalised strings with deterministic fallback."""
+
+        items: List[str] = []
+        if value is None:
+            items.append(default)
+            self.transform_log.append(f"Injected default for {default}")
+            return items
+
+        if isinstance(value, str):
+            candidate = value.strip()
+            if candidate:
+                items.append(candidate)
+        elif isinstance(value, Mapping):
+            for entry in value.values():
+                candidate = str(entry).strip()
+                if candidate:
+                    items.append(candidate)
+        elif isinstance(value, (list, tuple, set)):
+            for entry in value:
+                candidate = str(entry).strip()
+                if candidate:
+                    items.append(candidate)
+        else:
+            candidate = str(value).strip()
+            if candidate:
+                items.append(candidate)
+
+        if not items:
+            items.append(default)
+            self.transform_log.append(f"Injected default for {default}")
+        else:
+            self.transform_log.append(f"Normalised sequence for default={default}")
+        return items
+
+
+__all__ = ["DemoWorkOrder", "SubPlannerAdapterFake"]

--- a/backend/agents/validator/fake_validator.py
+++ b/backend/agents/validator/fake_validator.py
@@ -1,0 +1,65 @@
+"""Validator fake that always succeeds while surfacing informational warnings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Mapping
+from uuid import UUID, uuid5
+
+from backend.agents.orchestrator.routing import ValidatorService
+
+_VALIDATION_NAMESPACE = UUID("87654321-4321-8765-4321-876543218765")
+
+
+@dataclass(frozen=True)
+class FakeValidationReport:
+    """Minimal validation report used by the demo orchestrator wiring."""
+
+    step_id: str
+    fatal: List[Mapping[str, object]]
+    warnings: List[Mapping[str, object]]
+    metrics: Mapping[str, object]
+    fatal_count: int
+    warnings_count: int
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a mapping representation compatible with the repo interface."""
+
+        return {
+            "step_id": self.step_id,
+            "fatal": list(self.fatal),
+            "warnings": list(self.warnings),
+            "metrics": dict(self.metrics),
+            "fatal_count": self.fatal_count,
+            "warnings_count": self.warnings_count,
+        }
+
+
+class FakeValidator(ValidatorService):
+    """Validator fake that records metrics but never blocks progress."""
+
+    def validate(self, diff: str, base_ref: str, feature_ref: str) -> FakeValidationReport:
+        """Return a validation report with warnings but no fatal issues."""
+
+        warnings: List[Mapping[str, object]] = []
+        if diff:
+            warnings.append(
+                {
+                    "code": "INFO_PLACEHOLDER",
+                    "file": "frontend/app/settings.tsx",
+                    "msg": "Reminder: replace placeholder copy before shipping.",
+                }
+            )
+        report_id = str(uuid5(_VALIDATION_NAMESPACE, feature_ref))
+        metrics = {"lint_errors": 0, "tests_run": 0, "tests_failed": 0}
+        return FakeValidationReport(
+            step_id=report_id,
+            fatal=[],
+            warnings=warnings,
+            metrics=metrics,
+            fatal_count=0,
+            warnings_count=len(warnings),
+        )
+
+
+__all__ = ["FakeValidationReport", "FakeValidator"]

--- a/core/events/capture.py
+++ b/core/events/capture.py
@@ -1,0 +1,87 @@
+"""Helpers for capturing lifecycle events inside demo workflows."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import IO, Iterable, List, Mapping, Sequence
+
+from core.events.publisher import EventsPublisher
+from core.events.types import LifecycleEvent
+
+
+@dataclass(frozen=True)
+class CapturedEvent:
+    """Wrapper combining the canonical event and its serialized payload."""
+
+    event: LifecycleEvent
+    payload: Mapping[str, object]
+
+
+class InMemoryEventsPublisher(EventsPublisher):
+    """Event publisher that stores events and prints structured lines.
+
+    The demo wiring relies on this publisher to provide human-friendly
+    observability without requiring an external streaming service. Each
+    published event is appended to :attr:`events` and emitted as a single
+    JSON line on ``stdout`` (or the provided stream) so that the CLI can
+    replay the lifecycle transitions in order.
+    """
+
+    def __init__(self, stream: IO[str] | None = None) -> None:
+        self._stream: IO[str] = stream or sys.stdout
+        self._events: List[CapturedEvent] = []
+
+    @property
+    def events(self) -> Sequence[CapturedEvent]:
+        """Expose the captured events for assertions and summaries."""
+
+        return list(self._events)
+
+    def publish(self, event: LifecycleEvent) -> None:
+        """Persist ``event`` and echo a JSON line for human consumption."""
+
+        payload = self._serialise_event(event)
+        self._events.append(CapturedEvent(event=event, payload=payload))
+        json_record = json.dumps(payload, sort_keys=True)
+        self._stream.write(json_record + "\n")
+        self._stream.flush()
+
+    def list_events(self, run_id: str | None = None) -> Sequence[LifecycleEvent]:
+        """Return the published events filtered by ``run_id`` when provided."""
+
+        if run_id is None:
+            return [captured.event for captured in self._events]
+        return [captured.event for captured in self._events if captured.event.run_id == run_id]
+
+    def iter_payloads(self) -> Iterable[Mapping[str, object]]:
+        """Yield the serialized payloads in the order they were published."""
+
+        for captured in self._events:
+            yield captured.payload
+
+    def _serialise_event(self, event: LifecycleEvent) -> Mapping[str, object]:
+        """Serialise ``event`` into a deterministic mapping for printing."""
+
+        timestamp = event.timestamp if isinstance(event.timestamp, datetime) else datetime.fromisoformat(
+            str(event.timestamp)
+        )
+        payload: dict[str, object] = {
+            "ts": timestamp.isoformat(),
+            "level": "info",
+            "run_id": event.run_id,
+            "step_id": event.step_id,
+            "agent": "orchestrator",
+            "phase": event.state,
+            "message": event.event_type.value,
+        }
+        if event.duration_ms is not None:
+            payload["duration_ms"] = event.duration_ms
+        if event.meta is not None:
+            payload["meta"] = dict(event.meta)
+        return payload
+
+
+__all__ = ["CapturedEvent", "InMemoryEventsPublisher"]

--- a/core/store/memory_repos.py
+++ b/core/store/memory_repos.py
@@ -1,0 +1,365 @@
+"""In-memory repositories used by the demo orchestrator wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from itertools import count
+from typing import Collection, Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+from backend.agents.orchestrator.orchestrator_state import RunState, StepState
+from core.store.repositories import ArtifactRepo, PRBindingRepo, RunRepo, StepRepo, ValidationReportRepo
+
+
+@dataclass
+class RunRecord:
+    """Representation of a run persisted in memory."""
+
+    run_id: str
+    repo: str
+    base_ref: str
+    feature_ref: str
+    status: RunState
+    config: Mapping[str, object]
+    created_at: datetime
+    updated_at: datetime
+    meta: MutableMapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a serialisable snapshot of the run."""
+
+        return {
+            "id": self.run_id,
+            "repo": self.repo,
+            "base_ref": self.base_ref,
+            "feature_ref": self.feature_ref,
+            "status": self.status,
+            "config": dict(self.config),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "meta": dict(self.meta),
+        }
+
+
+@dataclass
+class StepRecord:
+    """Representation of a run step tracked in memory."""
+
+    run_id: str
+    step_id: str
+    index: int
+    title: str
+    body: str
+    state: StepState
+    created_at: datetime
+    updated_at: datetime
+    plan: MutableMapping[str, object] | None = None
+    work_order: MutableMapping[str, object] | None = None
+    coder_result: MutableMapping[str, object] | None = None
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a mapping copy suitable for repository consumers."""
+
+        payload: MutableMapping[str, object] = {
+            "id": self.step_id,
+            "index": self.index,
+            "title": self.title,
+            "body": self.body,
+            "state": self.state.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+        if self.plan is not None:
+            payload["plan"] = dict(self.plan)
+        if self.work_order is not None:
+            payload["work_order"] = dict(self.work_order)
+        if self.coder_result is not None:
+            payload["coder_result"] = dict(self.coder_result)
+        return payload
+
+
+@dataclass
+class ArtifactRecord:
+    """Artifact snapshot persisted by :class:`InMemoryArtifactRepo`."""
+
+    artifact_id: str
+    run_id: str
+    step_id: str
+    kind: str
+    content: str
+    meta: Mapping[str, object]
+    created_at: datetime
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a mapping representation for assertions and debugging."""
+
+        return {
+            "id": self.artifact_id,
+            "run_id": self.run_id,
+            "step_id": self.step_id,
+            "kind": self.kind,
+            "content": self.content,
+            "meta": dict(self.meta),
+            "created_at": self.created_at,
+        }
+
+
+@dataclass
+class ValidationReportRecord:
+    """Validation report snapshot tracked for demo purposes."""
+
+    report_id: str
+    run_id: str
+    step_id: str
+    report: Mapping[str, object]
+    fatal_count: int
+    warnings_count: int
+    created_at: datetime
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a copy of the stored validation report."""
+
+        return {
+            "id": self.report_id,
+            "run_id": self.run_id,
+            "step_id": self.step_id,
+            "report": dict(self.report),
+            "fatal_count": self.fatal_count,
+            "warnings_count": self.warnings_count,
+            "created_at": self.created_at,
+        }
+
+
+class InMemoryRunRepo(RunRepo):
+    """In-memory implementation of :class:`RunRepo` for demos and tests."""
+
+    def __init__(self) -> None:
+        self._runs: Dict[str, RunRecord] = {}
+        self._counter = count(1)
+
+    def create_run(
+        self,
+        *,
+        repo: str,
+        base_ref: str,
+        feature_ref: str,
+        status: RunState,
+        config: Mapping[str, object] | None = None,
+    ) -> str:
+        run_index = next(self._counter)
+        run_id = f"run-{run_index:04d}"
+        now = datetime.now(timezone.utc)
+        record = RunRecord(
+            run_id=run_id,
+            repo=repo,
+            base_ref=base_ref,
+            feature_ref=feature_ref,
+            status=status,
+            config=dict(config or {}),
+            created_at=now,
+            updated_at=now,
+        )
+        self._runs[run_id] = record
+        return run_id
+
+    def get_run(self, run_id: str) -> Mapping[str, object] | None:
+        record = self._runs.get(run_id)
+        return record.to_dict() if record else None
+
+    def update_run_state(self, run_id: str, state: RunState) -> None:
+        record = self._runs[run_id]
+        record.status = state
+        record.updated_at = datetime.now(timezone.utc)
+
+    def list_runs(self) -> Sequence[Mapping[str, object]]:
+        """Return all stored runs for inspection."""
+
+        return [record.to_dict() for record in self._runs.values()]
+
+
+class InMemoryStepRepo(StepRepo):
+    """In-memory implementation of :class:`StepRepo`."""
+
+    def __init__(self) -> None:
+        self._steps: Dict[str, List[StepRecord]] = {}
+
+    def create_steps(
+        self, run_id: str, steps: Sequence[Mapping[str, object]]
+    ) -> Sequence[Mapping[str, object]]:
+        now = datetime.now(timezone.utc)
+        stored: List[StepRecord] = []
+        for step in steps:
+            step_id = str(step.get("id"))
+            stored.append(
+                StepRecord(
+                    run_id=run_id,
+                    step_id=step_id,
+                    index=int(step.get("index", len(stored))),
+                    title=str(step.get("title", "")),
+                    body=str(step.get("body", "")),
+                    state=StepState(step.get("state", StepState.QUEUED.value)),
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        self._steps[run_id] = stored
+        return [record.to_dict() for record in stored]
+
+    def list_steps(self, run_id: str) -> Sequence[Mapping[str, object]]:
+        return [record.to_dict() for record in self._steps.get(run_id, [])]
+
+    def update_step_state(self, run_id: str, step_id: str, state: StepState) -> None:
+        for record in self._steps.get(run_id, []):
+            if record.step_id == step_id:
+                record.state = state
+                record.updated_at = datetime.now(timezone.utc)
+                break
+
+    def update_step_metadata(
+        self,
+        run_id: str,
+        step_id: str,
+        *,
+        plan: Mapping[str, object] | None = None,
+        work_order: Mapping[str, object] | None = None,
+        coder_result: Mapping[str, object] | None = None,
+    ) -> None:
+        for record in self._steps.get(run_id, []):
+            if record.step_id != step_id:
+                continue
+            if plan is not None:
+                record.plan = dict(plan)
+            if work_order is not None:
+                record.work_order = dict(work_order)
+            if coder_result is not None:
+                record.coder_result = dict(coder_result)
+            record.updated_at = datetime.now(timezone.utc)
+            break
+
+    def list_step_states(self, run_id: str) -> Iterable[StepState]:
+        """Yield the current states for each step in ``run_id``."""
+
+        for record in self._steps.get(run_id, []):
+            yield record.state
+
+
+class InMemoryArtifactRepo(ArtifactRepo):
+    """In-memory implementation of :class:`ArtifactRepo`."""
+
+    def __init__(self) -> None:
+        self._artifacts: List[ArtifactRecord] = []
+        self._counter = count(1)
+
+    def add(
+        self,
+        *,
+        run_id: str,
+        step_id: str,
+        kind: str,
+        content: str,
+        meta: Mapping[str, object] | None = None,
+    ) -> None:
+        artifact_id = f"artifact-{next(self._counter):04d}"
+        record = ArtifactRecord(
+            artifact_id=artifact_id,
+            run_id=run_id,
+            step_id=step_id,
+            kind=kind,
+            content=content,
+            meta=dict(meta or {}),
+            created_at=datetime.now(timezone.utc),
+        )
+        self._artifacts.append(record)
+
+    def list_artifacts(self, step_id: str) -> Sequence[Mapping[str, object]]:
+        """Return artifacts associated with ``step_id``."""
+
+        return [record.to_dict() for record in self._artifacts if record.step_id == step_id]
+
+    def all_artifacts(self) -> Sequence[Mapping[str, object]]:
+        """Return all stored artifacts."""
+
+        return [record.to_dict() for record in self._artifacts]
+
+
+class InMemoryValidationReportRepo(ValidationReportRepo):
+    """In-memory implementation of :class:`ValidationReportRepo`."""
+
+    def __init__(self) -> None:
+        self._reports: List[ValidationReportRecord] = []
+        self._counter = count(1)
+
+    def add(
+        self,
+        *,
+        run_id: str,
+        step_id: str,
+        report: Mapping[str, object],
+    ) -> None:
+        fatal = report.get("fatal")
+        warnings = report.get("warnings")
+        fatal_count = self._safe_len(fatal)
+        warnings_count = self._safe_len(warnings)
+        record = ValidationReportRecord(
+            report_id=f"report-{next(self._counter):04d}",
+            run_id=run_id,
+            step_id=step_id,
+            report=dict(report),
+            fatal_count=fatal_count,
+            warnings_count=warnings_count,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._reports.append(record)
+
+    def list_reports(self, run_id: str | None = None) -> Sequence[Mapping[str, object]]:
+        """Return stored reports, optionally filtered by ``run_id``."""
+
+        records = self._reports
+        if run_id is not None:
+            records = [record for record in records if record.run_id == run_id]
+        return [record.to_dict() for record in records]
+
+    @staticmethod
+    def _safe_len(candidate: object | None) -> int:
+        """Return ``len(candidate)`` when the value behaves like a collection."""
+
+        if candidate is None:
+            return 0
+        if isinstance(candidate, (str, bytes)):
+            return 0
+        if isinstance(candidate, Collection):
+            return len(candidate)
+        if isinstance(candidate, Iterable):
+            return sum(1 for _ in candidate)
+        return 0
+
+
+class InMemoryPRBindingRepo(PRBindingRepo):
+    """In-memory implementation of :class:`PRBindingRepo`."""
+
+    def __init__(self) -> None:
+        self._bindings: Dict[str, Mapping[str, object]] = {}
+
+    def get(self, run_id: str) -> Mapping[str, object] | None:
+        return self._bindings.get(run_id)
+
+    def upsert(self, run_id: str, metadata: Mapping[str, object]) -> None:
+        self._bindings[run_id] = dict(metadata)
+
+    def list_bindings(self) -> Mapping[str, Mapping[str, object]]:
+        """Return all stored PR bindings."""
+
+        return {run_id: dict(metadata) for run_id, metadata in self._bindings.items()}
+
+
+__all__ = [
+    "InMemoryArtifactRepo",
+    "InMemoryPRBindingRepo",
+    "InMemoryRunRepo",
+    "InMemoryStepRepo",
+    "InMemoryValidationReportRepo",
+    "RunRecord",
+    "StepRecord",
+    "ArtifactRecord",
+    "ValidationReportRecord",
+]

--- a/scripts/demo_happy_path.py
+++ b/scripts/demo_happy_path.py
@@ -1,0 +1,77 @@
+"""Run the happy-path orchestrator demo using in-memory fakes."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from backend.agents.orchestrator.orchestrator_state import StepState
+from backend.agents.orchestrator.wiring_demo import DemoOrchestratorContext, build_demo_orchestrator
+
+DEMO_STEPS: Sequence[dict[str, object]] = (
+    {
+        "title": "Add Settings route scaffold",
+        "body": "Create placeholder Settings page in the frontend app",
+    },
+    {
+        "title": "Add placeholder tests for Settings route",
+        "body": "Outline tests ensuring the Settings page renders",
+    },
+)
+
+
+def main() -> int:
+    """Execute the end-to-end happy-path demo."""
+
+    os.environ.setdefault("SIZE_GUARDS_ENABLED", "false")
+    context = build_demo_orchestrator()
+    orchestrator = context.orchestrator
+
+    run_id = orchestrator.start_run(repo="org/demo-repo", base_ref="main", steps=list(DEMO_STEPS))
+
+    _drain_steps(context, run_id)
+    _print_event_summary(context, run_id)
+    _print_artifact_summary(context, run_id)
+
+    return 0
+
+
+def _drain_steps(context: DemoOrchestratorContext, run_id: str) -> None:
+    """Advance steps sequentially until the run reaches a terminal state."""
+
+    while True:
+        step_records = context.step_repo.list_steps(run_id)
+        pending = [record for record in step_records if record.get("state") not in {StepState.PR_UPDATED.value, StepState.MERGED.value}]
+        if not pending:
+            break
+        orchestrator = context.orchestrator
+        orchestrator.advance_step(run_id)
+
+
+def _print_event_summary(context: DemoOrchestratorContext, run_id: str) -> None:
+    """Print the lifecycle events emitted during the run."""
+
+    for event in context.events.list_events(run_id):
+        step_id = event.step_id or "-"
+        print(
+            f"{event.timestamp.isoformat()} run={event.run_id} step={step_id} "
+            f"state={event.state} event={event.event_type.value}"
+        )
+
+
+def _print_artifact_summary(context: DemoOrchestratorContext, run_id: str) -> None:
+    """Print a short artifact summary to highlight diff persistence."""
+
+    for step in context.step_repo.list_steps(run_id):
+        artifacts = context.artifact_repo.list_artifacts(str(step["id"]))
+        print(f"Artifacts for {step['id']}: {[artifact['kind'] for artifact in artifacts]}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_demo_happy_path.py
+++ b/tests/integration/test_demo_happy_path.py
@@ -1,0 +1,46 @@
+"""Integration test covering the happy-path demo wiring."""
+
+from __future__ import annotations
+
+from backend.agents.orchestrator.orchestrator_state import StepState
+from backend.agents.orchestrator.wiring_demo import build_demo_orchestrator
+from scripts.demo_happy_path import DEMO_STEPS
+
+
+def test_demo_happy_path_executes_full_lifecycle(monkeypatch) -> None:
+    """Ensure the orchestrator with fakes runs both steps without pausing."""
+
+    monkeypatch.setenv("SIZE_GUARDS_ENABLED", "false")
+    context = build_demo_orchestrator()
+    run_id = context.orchestrator.start_run(
+        repo="org/demo-repo", base_ref="main", steps=list(DEMO_STEPS)
+    )
+
+    terminal_states = {StepState.PR_UPDATED.value, StepState.MERGED.value}
+    while True:
+        step_records = context.step_repo.list_steps(run_id)
+        if all(record.get("state") in terminal_states for record in step_records):
+            break
+        context.orchestrator.advance_step(run_id)
+
+    step_states = {record["id"]: record["state"] for record in context.step_repo.list_steps(run_id)}
+    assert step_states
+    assert all(state in terminal_states for state in step_states.values())
+
+    events = context.events.list_events(run_id)
+    event_types = [event.event_type.value for event in events]
+    assert event_types[:1] == ["run.status_changed"]
+    assert event_types.count("step.planned") == 2
+    assert event_types.count("step.executing") == 2
+    assert event_types.count("step.validated") == 2
+    committed_events = [event for event in events if event.event_type.value == "step.committed"]
+    assert len(committed_events) >= 4
+    assert event_types[-1] == "run.status_changed"
+
+    artifacts = context.artifact_repo.all_artifacts()
+    diff_artifacts = [artifact for artifact in artifacts if artifact["kind"] == "diff"]
+    assert diff_artifacts, "expected diff artifact to be persisted"
+
+    reports = context.report_repo.list_reports(run_id)
+    assert reports
+    assert all(report["fatal_count"] == 0 for report in reports)


### PR DESCRIPTION
## Summary
- add deterministic in-memory repositories, event publisher, and adapter fakes to exercise the orchestrator without external services
- expose a demo CLI that runs a two-step happy path and prints lifecycle events plus persisted artifacts
- cover the flow with an integration test that asserts event sequencing, diff artifacts, and validator output

## Testing
- python -m pytest
- python -m pytest tests/integration/test_demo_happy_path.py
- python scripts/demo_happy_path.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd1b9e6d48331954ffc3e7debe38d